### PR TITLE
Database Flags, Engine improvements

### DIFF
--- a/DuplicateFinderEngine/Data/DuplicateItem.cs
+++ b/DuplicateFinderEngine/Data/DuplicateItem.cs
@@ -70,6 +70,11 @@ namespace DuplicateFinderEngine.Data {
 		public DateTime DateCreated { get; }
 
 		public bool IsImage { get; }
-
+		public event Action ThumbnailUpdated;
+		internal void UpdateThumbnails(List<Image> th) {
+			if(th == null) return;
+			Thumbnail = th;
+			ThumbnailUpdated?.Invoke(); 
+		}
 	}
 }

--- a/DuplicateFinderEngine/Data/VideoFileEntry.cs
+++ b/DuplicateFinderEngine/Data/VideoFileEntry.cs
@@ -4,20 +4,37 @@ using DuplicateFinderEngine.FFProbeWrapper;
 using System.Collections.Generic;
 using ProtoBuf;
 
-namespace DuplicateFinderEngine.Data
-{
-    [ProtoContract]
-    public class VideoFileEntry {
-	    protected VideoFileEntry() {}
-        public VideoFileEntry(string file)
-        {
-            Path = file;
-            var fi = new System.IO.FileInfo(file);
+namespace DuplicateFinderEngine.Data {
+	[Flags]
+	public enum EntryFlags {
+		IsImage = 1,
+		ManuallyExcluded = 2,
+		ThumbnailError = 4,
+		MetadataError = 8,
+		TooDark = 16,
+
+		AllErrors = ThumbnailError | MetadataError | TooDark
+	}
+
+	public static class EntryFlagExtensions {
+		public static bool Any(this EntryFlags f, EntryFlags checkFlags) => (f & checkFlags) > 0;
+		public static bool Has(this EntryFlags f, EntryFlags checkFlags) => (f & checkFlags) == checkFlags;
+		public static void Set(this ref EntryFlags f, EntryFlags setFlag) => f = f | setFlag;
+		public static void Set(this ref EntryFlags f, EntryFlags setFlag, bool falseToReset) => f = (f & ~setFlag) | (falseToReset ? setFlag : 0);
+	}
+
+
+	[ProtoContract]
+	public class VideoFileEntry {
+		protected VideoFileEntry() { }
+		public VideoFileEntry(string file) {
+			Path = file;
+			var fi = new System.IO.FileInfo(file);
 			Folder = fi.Directory?.FullName;
-            var extension = fi.Extension;
-            IsImage = FileHelper.ImageExtensions.Any(x => extension.EndsWith(x, StringComparison.OrdinalIgnoreCase));
-        }
-        [ProtoMember(1)]
+			var extension = fi.Extension;
+			IsImage = FileHelper.ImageExtensions.Any(x => extension.EndsWith(x, StringComparison.OrdinalIgnoreCase));
+		}
+		[ProtoMember(1)]
 		public string Path;
 		[ProtoMember(2)]
 		public string Folder;
@@ -26,6 +43,11 @@ namespace DuplicateFinderEngine.Data
 		[ProtoMember(4)]
 		public MediaInfo mediaInfo;
 		[ProtoMember(5)]
-		public readonly bool IsImage;
-    }
+		public EntryFlags Flags;
+
+		public bool IsImage {
+			get => Flags.Has(EntryFlags.IsImage);
+			protected set => Flags.Set(EntryFlags.IsImage, value);
+		}
+	}
 }

--- a/DuplicateFinderEngine/DuplicateFinderEngine.csproj
+++ b/DuplicateFinderEngine/DuplicateFinderEngine.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <Platforms>AnyCPU;x64</Platforms>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/VideoDuplicateFinder.Windows/App.xaml.cs
+++ b/VideoDuplicateFinder.Windows/App.xaml.cs
@@ -1,35 +1,41 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Threading;
 
-namespace VideoDuplicateFinderWindows
-{
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
-    public partial class App : Application
-    {
-        static void InstallExceptionHandlers()
-        {
-            TaskScheduler.UnobservedTaskException += (s, e) => e.SetObserved();
-            if (Debugger.IsAttached) return;
-            AppDomain.CurrentDomain.UnhandledException += (s, e) => ShowException(e.ExceptionObject as Exception);
-            Dispatcher.CurrentDispatcher.UnhandledException += (s, e) =>
-            {
-                ShowException(e.Exception);
-                e.Handled = true;
-            };
-        }
-        static void ShowException(Exception ex)
-        {
-            string msg = ex?.ToString() ?? "Unknown exception";
-            MessageBox.Show(msg, "Video Duplicate Finder", MessageBoxButton.OK, MessageBoxImage.Error);
-        }
-        public App()
-        {
-            InstallExceptionHandlers();
-        }
-    }
+namespace VideoDuplicateFinderWindows {
+	/// <summary>
+	/// Interaction logic for App.xaml
+	/// </summary>
+	public partial class App : Application { }
+
+	public static class Startup {
+
+		static void InstallExceptionHandlers() {
+			TaskScheduler.UnobservedTaskException += (s, e) => { ShowException("TaskScheduler.UnobservedTask", e.Exception); e.SetObserved(); };
+
+			if (Debugger.IsAttached) return;
+
+			AppDomain.CurrentDomain.UnhandledException += (s, e) => ShowException("CurrentDomain.Unhandled", e.ExceptionObject as Exception);
+			Dispatcher.CurrentDispatcher.UnhandledException += (s, e) => { ShowException("CurrentDispatcher.Unhandled", e.Exception); e.Handled = true; };
+		}
+
+		static void ShowException(string type, Exception ex) {
+			string msg = ex?.ToString() ?? "Unknown exception";
+			MessageBox.Show(msg, $"{type}Exception", MessageBoxButton.OK, MessageBoxImage.Error);
+		}
+
+		/// <summary>
+		/// Custom Application Entry Point, to catch exceptions in WPF app constructor
+		/// </summary>
+		[System.STAThreadAttribute()]
+		public static void Main() {
+			InstallExceptionHandlers();
+
+			var app = new App();
+			app.InitializeComponent();
+			app.Run();
+		}
+	}
 }

--- a/VideoDuplicateFinder.Windows/Data/DuplicateItem.cs
+++ b/VideoDuplicateFinder.Windows/Data/DuplicateItem.cs
@@ -8,7 +8,7 @@ namespace VideoDuplicateFinderWindows.Data
 {
     public class DuplicateItemViewModel : ViewModelBase, IEquatable<DuplicateItemViewModel>
     {
-        public DuplicateItemViewModel(DuplicateFinderEngine.Data.DuplicateItem file)
+		public DuplicateItemViewModel(DuplicateFinderEngine.Data.DuplicateItem file)
         {
             Path = file.Path;
             Folder = file.Folder;
@@ -28,6 +28,10 @@ namespace VideoDuplicateFinderWindows.Data
             BitRateKbs = file.BitRateKbs;
             Similarity = file.Similarity;
             IsImage = file.IsImage;
+			file.ThumbnailUpdated += () => {
+				Thumbnail = Utils.JoinImages(file.Thumbnail);
+				OnPropertyChanged(nameof(Thumbnail));
+			};
         }
 
 

--- a/VideoDuplicateFinder.Windows/MainWindow.xaml
+++ b/VideoDuplicateFinder.Windows/MainWindow.xaml
@@ -139,11 +139,22 @@
                                     </Viewbox>
                                 </MenuItem.Icon>
                             </MenuItem>
-                            <MenuItem Header="{x:Static properties:Resources.Export}">
-                                <MenuItem Command="{Binding ExportDatabaseVideosToCSVCommand}"
-                                          Visibility="{Binding IsScanning, Converter={StaticResource InvertBooleanToVisibilityConverter}}" >
+                            <MenuItem Header="{x:Static properties:Resources.Export}" Visibility="{Binding IsScanning, Converter={StaticResource InvertBooleanToVisibilityConverter}}">
+                                <MenuItem Command="{Binding ExportDatabaseVideosToCSVCommand}">
                                     <MenuItem.Header>
                                         <TextBlock Text="{x:Static properties:Resources.ExportDatabaseVideosToCSV}" VerticalAlignment="Center"/>
+                                    </MenuItem.Header>
+                                    <MenuItem.Icon>
+                                        <Viewbox Width="16" Height="16">
+                                            <Canvas Width="24" Height="24">
+                                                <Path Data="M14.22,19L17.05,16.17L14.93,14H22V21.07L19.88,19L17.05,21.83L14.22,19M11.39,19L12.39,18H12C7.58,18 4,16.21 4,14V17C4,19.21 7.58,21 12,21C12.47,21 12.93,21 13.38,20.94L11.39,19M17.29,12H20V9C20,10.2 19,11.27 17.29,12M4,9V12C4,14.21 7.58,16 12,16C12.67,16 13.34,15.96 14,15.87L11.07,13C7.09,12.74 4,11.05 4,9M12,3C7.58,3 4,4.79 4,7C4,9.21 7.58,11 12,11C16.42,11 20,9.21 20,7C20,4.79 16.42,3 12,3Z" Fill="Black" />
+                                            </Canvas>
+                                        </Viewbox>
+                                    </MenuItem.Icon>
+                                </MenuItem>
+                                <MenuItem Command="{Binding ExportDatabaseExcluded}">
+                                    <MenuItem.Header>
+                                        <TextBlock Text="{x:Static properties:Resources.ExportDatabaseExcluded}" VerticalAlignment="Center"/>
                                     </MenuItem.Header>
                                     <MenuItem.Icon>
                                         <Viewbox Width="16" Height="16">

--- a/VideoDuplicateFinder.Windows/Properties/Resources.Designer.cs
+++ b/VideoDuplicateFinder.Windows/Properties/Resources.Designer.cs
@@ -250,6 +250,15 @@ namespace VideoDuplicateFinder.Windows.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export Excluded to CSV.
+        /// </summary>
+        public static string ExportDatabaseExcluded {
+            get {
+                return ResourceManager.GetString("ExportDatabaseExcluded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Export Database videos to CSV.
         /// </summary>
         public static string ExportDatabaseVideosToCSV {
@@ -259,7 +268,7 @@ namespace VideoDuplicateFinder.Windows.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exporting database videos to CSV....
+        ///   Looks up a localized string similar to Exporting database to CSV....
         /// </summary>
         public static string ExportingDatabaseVideosToCSV {
             get {

--- a/VideoDuplicateFinder.Windows/Properties/Resources.resx
+++ b/VideoDuplicateFinder.Windows/Properties/Resources.resx
@@ -1,76 +1,96 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
-		Microsoft ResX Schema
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
           <xsd:element name="data">
             <xsd:complexType>
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -89,13 +109,13 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-    <value>1.3</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CopyingFiles" xml:space="preserve">
     <value>Copying files...</value>
@@ -293,7 +313,7 @@
     <value>File Type</value>
   </data>
   <data name="ExportingDatabaseVideosToCSV" xml:space="preserve">
-    <value>Exporting database videos to CSV...</value>
+    <value>Exporting database to CSV...</value>
   </data>
   <data name="Database" xml:space="preserve">
     <value>Database</value>
@@ -312,5 +332,8 @@
   </data>
   <data name="Percent" xml:space="preserve">
     <value>Percent:</value>
+  </data>
+  <data name="ExportDatabaseExcluded" xml:space="preserve">
+    <value>Export Excluded to CSV</value>
   </data>
 </root>

--- a/VideoDuplicateFinder.Windows/Utils.cs
+++ b/VideoDuplicateFinder.Windows/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
@@ -60,6 +60,7 @@ namespace VideoDuplicateFinderWindows
         }
         public static BitmapImage JoinImages(List<Image> pImgList)
         {
+			if(pImgList.Count == 0) return null;
             if (pImgList.Count == 1)
                 return BitmapToBitmapImage(pImgList[0]);
             var height = pImgList[0].Height;

--- a/VideoDuplicateFinder.Windows/VideoDuplicateFinder.Windows.csproj
+++ b/VideoDuplicateFinder.Windows/VideoDuplicateFinder.Windows.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -8,6 +8,7 @@
     <SignAssembly>false</SignAssembly>
     <Platforms>AnyCPU</Platforms>
     <AssemblyName>VideoDuplicateFinderWindows</AssemblyName>
+    <StartupObject>VideoDuplicateFinderWindows.Startup</StartupObject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/VideoDuplicateFinderLinux/DuplicateItemViewModel.cs
+++ b/VideoDuplicateFinderLinux/DuplicateItemViewModel.cs
@@ -28,6 +28,10 @@ namespace VideoDuplicateFinderLinux
             BitRateKbs = file.BitRateKbs;
             Similarity = file.Similarity;
             IsImage = file.IsImage;
+			file.ThumbnailUpdated += () => {
+				Thumbnail = Utils.JoinImages(file.Thumbnail);
+				//TODO: PropertyChanged(nameof(Thumbnail));
+			};
         }
 
 		/*

--- a/VideoDuplicateFinderLinux/Utils.cs
+++ b/VideoDuplicateFinderLinux/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Avalonia.Media.Imaging;
 
@@ -9,6 +9,8 @@ namespace VideoDuplicateFinderLinux
         public static string ThumbnailDirectory => DuplicateFinderEngine.Utils.SafePathCombine(Path.GetDirectoryName(typeof(MainWindow).Assembly.Location), "Thumbnails");
         public static Bitmap JoinImages(List<System.Drawing.Image> pImgList)
         {
+			if(pImgList == null || pImgList.Count == 0) return null;
+
             var file =
                 DuplicateFinderEngine.Utils.SafePathCombine(ThumbnailDirectory, Path.GetRandomFileName() + ".jpeg");
           


### PR DESCRIPTION
 - catch exceptions in WPF initializer (like missing dll)
 - added flags for db entries (so broken files are not rescanned every time) 
 - - also a flag for future use, for the user to manually exclude files (not implemented in UI yet)
 - - extended csv export, option to show only excluded
 - improved dupechecking speed ~50%
 - display-thumbnail generation in separate step (not needed in console), and can run in background for GUI
 - - linux version needs to be adapted