### PR TITLE
Fix/speedup comparison, fixed timeout on stream copy

### DIFF
--- a/DuplicateFinderEngine/FFmpegWrapper/FFmpegSettings.cs
+++ b/DuplicateFinderEngine/FFmpegWrapper/FFmpegSettings.cs
@@ -5,6 +5,8 @@ namespace DuplicateFinderEngine.FFmpegWrapper
 
         public float Seek;
 		
+		public bool KeyframeOnly;
+
         public string VideoFrameSize;
 
         public string OutputFormat;

--- a/DuplicateFinderEngine/FFmpegWrapper/FFmpegWrapper.cs
+++ b/DuplicateFinderEngine/FFmpegWrapper/FFmpegWrapper.cs
@@ -67,7 +67,7 @@ namespace DuplicateFinderEngine.FFmpegWrapper {
 
 				WaitFFMpegProcessForExit();
 
-				imgDataTask.Wait(1000);
+				imgDataTask.Wait(ExecutionTimeout);
 				data = ms.ToArray();
 
 				FFMpegProcess?.Close();

--- a/DuplicateFinderEngine/ScanEngine.cs
+++ b/DuplicateFinderEngine/ScanEngine.cs
@@ -160,7 +160,7 @@ namespace DuplicateFinderEngine {
 
 		private void InternalSearch(CancellationToken cancelToken, PauseTokenSource pauseTokenSource) {
 			ElapsedTimer.Start();
-			SearchSW.Start();;
+			SearchSW.Start();
 			var duplicateDict = new Dictionary<string, DuplicateItem>();
 
 			try {
@@ -205,7 +205,7 @@ namespace DuplicateFinderEngine {
 				SearchSW.Restart();
 				var percentageDifference = 1.0f - Settings.Percent / 100f;
 				var dupeScanList = ScanFileList.Where(vf => !vf.Flags.Any(EntryFlags.AllErrors | EntryFlags.ManuallyExcluded)).ToList();
-
+				
 				InitProgress(dupeScanList.Count);
 				Parallel.For(0, dupeScanList.Count, parallelOpts, i => {
 					while (pauseTokenSource.IsPaused) Thread.Sleep(50);
@@ -439,12 +439,12 @@ namespace DuplicateFinderEngine {
 			}
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			public static float PercentageDifference2(byte[] img1, byte[] img2) {
-				if (img1.AsSpan().SequenceEqual(img2.AsSpan())) return 1f;
-				float diff = 0;
+				if(img1.Length != img2.Length) throw new Exception("Images must be of same length");
+				long diff = 0;
 				for (var y = 0; y < img1.Length; y++) {
-					diff += (float)Math.Abs(img1[y] - img2[y]) / 255;
+					diff += Math.Abs(img1[y] - img2[y]);
 				}
-				return diff / (16 * 16);
+				return (float)diff / img1.Length / 256;
 			}
 		}
 	}

--- a/DuplicateFinderEngine/ScanEngine.cs
+++ b/DuplicateFinderEngine/ScanEngine.cs
@@ -70,7 +70,12 @@ namespace DuplicateFinderEngine {
 		}
 
 		public async void CleanupDatabase() {
-			await Task.Run(() => DatabaseHelper.CleanupDatabase(DatabaseFileList));
+			if (DatabaseFileList.Count == 0) DatabaseFileList = DatabaseHelper.LoadDatabase();
+
+			await Task.Run(() => {
+				DatabaseFileList = DatabaseHelper.CleanupDatabase(DatabaseFileList);
+				DatabaseHelper.SaveDatabase(DatabaseFileList);
+			});
 			DatabaseCleaned?.Invoke(this, null);
 		}
 		public async void ExportDatabaseVideosToCSV(bool onlyVideos, bool onlyFlagged) {
@@ -334,9 +339,9 @@ namespace DuplicateFinderEngine {
 				videoFile.FrameSizeInt = bitmapImage.Width + bitmapImage.Height;
 
 				double resizeFactor = 1;
-				if (bitmapImage.Width > 100 || bitmapImage.Height > 100) {
-					double widthFactor = Convert.ToDouble(bitmapImage.Width) / 100;
-					double heightFactor = Convert.ToDouble(bitmapImage.Height) / 100;
+				if (bitmapImage.Width > 300 || bitmapImage.Height > 169) {
+					double widthFactor = Convert.ToDouble(bitmapImage.Width) / 300;
+					double heightFactor = Convert.ToDouble(bitmapImage.Height) / 169;
 					resizeFactor = Math.Max(widthFactor, heightFactor);
 
 				}
@@ -344,7 +349,7 @@ namespace DuplicateFinderEngine {
 				int height = Convert.ToInt32(bitmapImage.Height / resizeFactor);
 				var newImage = new Bitmap(width, height);
 				using (var g = Graphics.FromImage(newImage)) {
-					g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
+					g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.Bilinear;
 					g.DrawImage(bitmapImage, 0, 0, newImage.Width, newImage.Height);
 				}
 

--- a/DuplicateFinderEngine/ScanEngine.cs
+++ b/DuplicateFinderEngine/ScanEngine.cs
@@ -238,8 +238,12 @@ namespace DuplicateFinderEngine {
 							var foundComp = duplicateDict.TryGetValue(compItem.Path, out var existingComp);
 
 							if (foundBase && foundComp) {
-								foreach (var dup in duplicateDict.Values.Where(c => c.GroupId == existingComp.GroupId))
-									dup.GroupId = existingBase.GroupId;
+								//this happens with 4+ identical items:
+								//first, 2+ duplicate groups are found independently, they are merged in this branch
+								if (existingBase.GroupId != existingComp.GroupId) {
+									foreach (var dup in duplicateDict.Values.Where(c => c.GroupId == existingComp.GroupId))
+										dup.GroupId = existingBase.GroupId;
+								}
 							}
 							else if (foundBase) {
 								duplicateDict.Add(compItem.Path, new DuplicateItem(compItem, percSame) { GroupId = existingBase.GroupId });

--- a/VideoDuplicateFinder.Windows/ViewModels/DuplicateViewModel.xaml
+++ b/VideoDuplicateFinder.Windows/ViewModels/DuplicateViewModel.xaml
@@ -21,11 +21,11 @@
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="160" />
             <ColumnDefinition Width="300" />
+            <ColumnDefinition Width="90" />
             <ColumnDefinition Width="100" />
-            <ColumnDefinition Width="100" />
-            <ColumnDefinition Width="100" />
+            <ColumnDefinition Width="80" />
             <ColumnDefinition Width="75" />
         </Grid.ColumnDefinitions>
 
@@ -37,7 +37,11 @@
 
         <Image
             Grid.Column="1"
-            Margin="10,0,0,0"
+            Margin="10,-10,0,-10"
+            HorizontalAlignment="Center"
+            Stretch="Uniform"
+            Width="160"
+            Height="90"
             MouseLeftButtonDown="Image_MouseLeftButtonDown"
             Source="{Binding Thumbnail}" />
 


### PR DESCRIPTION
`if (img1.AsSpan().SequenceEqual(img2.AsSpan())) return 1f;`
should have been:
`if (img1.AsSpan().SequenceEqual(img2.AsSpan())) return 0f;`

anyway, it's ~20% faster now with a integer sum and without special case check