### PR TITLE
Fix file opening mode for database writing

### DIFF
--- a/DuplicateFinderEngine/DatabaseHelper.cs
+++ b/DuplicateFinderEngine/DatabaseHelper.cs
@@ -112,7 +112,7 @@ namespace DuplicateFinderEngine {
 		public static void SaveDatabase(Dictionary<string, VideoFileEntry> videoFiles) {
 			Logger.Instance.Info(string.Format(Properties.Resources.SaveScannedFilesToDisk0N0Files, videoFiles.Count));
 			using (var stream = new FileStream(Utils.SafePathCombine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
-				"ScannedFiles.db"), FileMode.OpenOrCreate)) {
+				"ScannedFiles.db"), FileMode.Create)) {
 				Serializer.Serialize(stream, videoFiles.Values.ToList());
 			}
 		}

--- a/DuplicateFinderEngine/ScanEngine.cs
+++ b/DuplicateFinderEngine/ScanEngine.cs
@@ -452,7 +452,7 @@ namespace DuplicateFinderEngine {
 			}
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			public static float PercentageDifference(byte[] img1, byte[] img2) {
-				if (img1.AsSpan().SequenceEqual(img2.AsSpan())) return 0f;
+				Debug.Assert(img1.Length == img2.Length, "Images must be of the same size");
 				long diff = 0;
 				for (var y = 0; y < img1.Length; y++) {
 					diff += Math.Abs(img1[y] - img2[y]);


### PR DESCRIPTION
With OpenOrCreate the file can never shrink, and this results in protobuf format errors after database cleanup, since the end of the file holds old / invalid data.

Also, I removed the SequenceEquals special case optimization, since a comparison and and a subtraction is the same thing on the cpu anyway. Even if sequenceEquals was faster for equal images, its not worth slowing down the expected 99% of comparisons with different contents