### PR TITLE
Fix unable to find ffmpeg in PATH when using Windows

### DIFF
--- a/DuplicateFinderEngine/Utils.cs
+++ b/DuplicateFinderEngine/Utils.cs
@@ -6,61 +6,54 @@ using System.Runtime.InteropServices;
 
 namespace DuplicateFinderEngine {
 	public static class Utils {
-		public const string FFprobeExecutableName = "ffprobe";
-		public const string FFmpegExecutableName = "ffmpeg";
-		public static string FfmpegPath { get; }
-		public static string FfprobePath { get; }
-
+		public static string FFprobeExecutableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffprobe.exe" : "ffprobe";
+		public static string FFmpegExecutableName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
 		private static readonly string[] suf = { " B", " KB", " MB", " GB", " TB", " PB", " EB" };
 
-		public static bool FfFilesExist {
-			get {
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-					return File.Exists(FfmpegPath + ".exe") && File.Exists(FfprobePath + ".exe");
+		private static string _ffmpegDirectory;
+
+		/// <summary>
+		/// Returns the full path to the ffmpeg executable.
+		/// </summary>
+		public static string FfmpegPath
+		{
+			get 
+			{
+				if (_ffmpegDirectory == null)
+				{
+					_ffmpegDirectory = FindFfmpegDirectory();
 				}
+
+				return Path.Combine(_ffmpegDirectory, FFmpegExecutableName);
+			}
+		}
+
+		/// <summary>
+		/// Returns the full path of the ffprobe executable.
+		/// </summary>
+		public static string FfprobePath
+		{
+			get
+			{
+				if (_ffmpegDirectory == null) 
+				{
+					_ffmpegDirectory = FindFfmpegDirectory();
+				}
+
+				return Path.Combine(_ffmpegDirectory, FFprobeExecutableName);
+			}
+		}
+
+		/// <summary>
+		/// Returns true if both ffmpeg and ffprobe can be found.
+		/// </summary>
+		public static bool FfFilesExist
+		{
+			get
+			{
 				return File.Exists(FfmpegPath) && File.Exists(FfprobePath);
 			}
 		}
-
-		static Utils() {
-			Logger.Instance.Info("OS: " + RuntimeInformation.OSDescription);
-			var currentDir = Path.GetDirectoryName(typeof(FFmpegWrapper.FFmpegWrapper).Assembly.Location);
-			var pathsEnv = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator);
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-				if (File.Exists(currentDir + $"\\bin\\{FFmpegExecutableName}.exe"))
-					FfmpegPath = currentDir + $"\\bin\\{FFmpegExecutableName}";
-				else if (File.Exists(currentDir + $"\\{FFmpegExecutableName}.exe"))
-					FfmpegPath = currentDir + $"\\{FFmpegExecutableName}";
-
-				if (File.Exists(currentDir + $"\\bin\\{FFprobeExecutableName}.exe"))
-					FfprobePath = currentDir + $"\\bin\\{FFprobeExecutableName}";
-				else if (File.Exists(currentDir + $"\\{FFprobeExecutableName}.exe"))
-					FfprobePath = currentDir + $"\\{FFprobeExecutableName}";
-			}
-
-
-			if (pathsEnv == null || (!string.IsNullOrEmpty(FfprobePath) && !string.IsNullOrEmpty(FfmpegPath))) return;
-			foreach (var path in pathsEnv) {
-				if (!Directory.Exists(path)) {
-					continue;
-				}
-				try {
-					var files = new DirectoryInfo(path).GetFiles();
-
-					if (string.IsNullOrEmpty(FfmpegPath))
-						FfmpegPath = files.FirstOrDefault(x => x.Name.StartsWith(FFmpegExecutableName, true, CultureInfo.InvariantCulture))
-							             ?.FullName ?? string.Empty;
-					if (string.IsNullOrEmpty(FfprobePath))
-						FfprobePath = files.FirstOrDefault(x => x.Name.StartsWith(FFprobeExecutableName, true, CultureInfo.InvariantCulture))
-							              ?.FullName ?? string.Empty;
-				}
-				catch (Exception e) {
-					Console.WriteLine(e);
-				}
-					
-			}
-		}
-		
 
 		/// <summary>
 		/// Trims milliseconds from a timespan making it better compare-able against another timespan
@@ -103,6 +96,71 @@ namespace DuplicateFinderEngine {
 
 			path2 = path2.TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 			return Path.Combine(path1, path2);
+		}
+
+		/// <summary>
+		/// Tries to find the location of an ffmpeg executable.
+		/// Searches next to the executable, inside the <executable>\bin directory and in PATH.
+		/// </summary>
+		/// <returns>Full path to the ffmpeg executable.</returns>
+		private static string FindFfmpegDirectory()
+		{
+			Logger.Instance.Info("OS: " + RuntimeInformation.OSDescription);
+			var currentDir = Path.GetDirectoryName(typeof(FFmpegWrapper.FFmpegWrapper).Assembly.Location);
+
+			// start discovery
+			if (File.Exists(Path.Combine(currentDir, FFmpegExecutableName)))
+			{
+				// it's next to FFmpegWrapper.dll
+				return currentDir;
+			}
+
+			if (File.Exists(Path.Combine(currentDir, "bin", FFmpegExecutableName)))
+			{
+				// it's in \bin
+				return Path.Combine(currentDir, "bin");
+			}
+
+			// try all directories in PATH
+			var pathsEnv = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator);
+			if (pathsEnv == null)
+			{
+				// if PATH doesn't exist, return null
+				return null;
+			}
+			else
+			{
+				// otherwise check each directory
+				foreach (var path in pathsEnv)
+				{
+					if (!Directory.Exists(path))
+					{
+						// if the directory doesn't even exist, continue on the next foreach item
+						continue;
+					}
+
+					try
+					{
+						// otherwise get all files in the directory
+						var files = new DirectoryInfo(path).GetFiles();
+
+						// get the first file whose name starts with FFmpegExecutableName
+						var result = files.FirstOrDefault(x => x.Name.StartsWith(FFmpegExecutableName, true, CultureInfo.InvariantCulture));
+						if (result != null)
+						{
+							// return its directory
+							return result.Directory.ToString();
+						}
+					}
+					catch (Exception e)
+					{
+						Console.WriteLine(e);
+					}
+				}
+
+				// didn't find anything in PATH either
+				return null;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The automatically discovered `FfmpegPath` was `ffmpeg.exe.exe`.

This PR fixes #90

Refactor Utils.cs
* add comments
* remove static constructor
* implement FindFfmpegDirectory
* assume ffmpeg and ffprobe is in the same directory