### PR TITLE
ImageUtils.JoinImages: Added non persistent mode using a memory stream.

### DIFF
--- a/VDF.GUI/Utils/ImageUtils.cs
+++ b/VDF.GUI/Utils/ImageUtils.cs
@@ -22,10 +22,8 @@ using VDF.Core.Utils;
 namespace VDF.GUI.Utils {
 	static class ImageUtils {
 		public static string ThumbnailDirectory => Core.Utils.FileUtils.SafePathCombine(CoreUtils.CurrentFolder, "Thumbnails");
-		public static Bitmap JoinImages(List<System.Drawing.Image> pImgList) {
+		public static Bitmap JoinImages(List<System.Drawing.Image> pImgList, bool persistent = false) {
 			if (pImgList == null || pImgList.Count == 0) return null;
-
-			string file = Core.Utils.FileUtils.SafePathCombine(ThumbnailDirectory, Path.GetRandomFileName() + ".jpeg");
 
 			int height = pImgList[0].Height;
 			int width = 0;
@@ -41,8 +39,20 @@ namespace VDF.GUI.Utils {
 				}
 				g.Save();
 			}
-			img.Save(file, img.RawFormat);
-			return new Bitmap(file);
+			
+			if (persistent) {
+				string file = Core.Utils.FileUtils.SafePathCombine(ThumbnailDirectory, Path.GetRandomFileName() + ".jpeg");
+				img.Save(file, img.RawFormat);
+				return new Bitmap(file);
+			}
+			else {
+				using (MemoryStream memory = new MemoryStream())
+				{
+					img.Save(memory, img.RawFormat);
+					memory.Position = 0;
+					return new Avalonia.Media.Imaging.Bitmap(memory);
+				}
+			}			
 		}
 	}
 }


### PR DESCRIPTION
-> Using a memory stream is faster and if the image files is not needed for other purpose there is no reason to store them.

In "Recognize horizontally flipped videos/Images as duplicate #148" I suggested not to create files for displaying the thumbnails, but to convert them into an Avalonia image via memory stream.

You meant:
> If you believe if you can make something faster without any drawbacks go ahead and make a PR.

So here is the small modification. If needed, the files can still be created by calling the function with persistent = true.