### PR TITLE
Bugfix/wrong metadata

### DIFF
--- a/VDF.Core/FFTools/FFProbeJsonReader.cs
+++ b/VDF.Core/FFTools/FFProbeJsonReader.cs
@@ -18,21 +18,197 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using VDF.Core.Utils;
+using System.Text.Json.Serialization;
+
+using DSO = System.Collections.Generic.Dictionary<string, object>; 
+using LO  = System.Collections.Generic.List <object>; 
 
 namespace VDF.Core.FFTools {
+
+#if true
+// ---------------------------------------------------------------------------------
+// V1) JSON -> JsonSerializer.Deserialize -> JsonMediaInfo class -> MediaInfo class
+// ---------------------------------------------------------------------------------
+
 	static class FFProbeJsonReader {
 
-		enum JsonObjects {
-			None,
-			Streams,
-			Format
+		public class JsonMediaInfo
+		{
+			#pragma warning disable CS0649 // Field is never assigned to, and will always have its default
+			public Format? format;
+			public List<Stream>? streams;
+
+			public class Format {
+				public string? bit_rate;
+				public string? duration;
+			}
+			public class Stream	{
+				public string? bit_rate;
+				public int width;
+				public int height;
+				public string? codec_name;
+				public string? codec_long_name;
+				public string? codec_type;
+				public string? channel_layout;
+				public string? pix_fmt;
+				public string? sample_rate;
+				public int index;
+				public string? r_frame_rate;
+				public Disposition? disposition;
+			}
+			public class Disposition {
+				[JsonPropertyName("default")]
+				public int default_;
+			}
+			#pragma warning restore CS0649 // Field is never assigned to, and will always have its default
 		}
 
-		// C# no-alloc optimization that directly wraps the data section of the dll (similar to string constants)
-		// https://github.com/dotnet/roslyn/pull/24621
-		static ReadOnlySpan<byte> StreamsKeyword => new byte[] { 0x73, 0x74, 0x72, 0x65, 0x61, 0x6D, 0x73 }; // = streams
-		static ReadOnlySpan<byte> FormatKeyword => new byte[] { 0x66, 0x6F, 0x72, 0x6D, 0x61, 0x74 }; // = format
-		static ReadOnlySpan<byte> IndexKeyword => new byte[] { 0x69, 0x6E, 0x64, 0x65, 0x78 }; // = index
+		static JsonSerializerOptions serializerOptions = new JsonSerializerOptions
+		{
+			IncludeFields = true,
+		};
+
+		/// <summary>
+		/// Parses FFprobe JSON output and returns a new <see cref="MediaInfo"/>
+		/// </summary>
+		/// <param name="data">JSON output</param>
+		/// <param name="file">The file the JSON output format is about</param>
+		/// <returns><see cref="MediaInfo"/> containing information from FFprobe output</returns>
+		public static MediaInfo Read(byte[] data, string file) {;
+
+			var json = new Utf8JsonReader(data);
+            var jsonInfo = JsonSerializer.Deserialize<JsonMediaInfo>(ref json, serializerOptions);
+
+			var info = new MediaInfo {
+				Streams = new MediaInfo.StreamInfo[jsonInfo?.streams?.Count ?? 0]
+			};
+
+			if (jsonInfo != null && jsonInfo.streams != null) {
+				if (jsonInfo.format?.duration != null && TimeSpan.TryParse(jsonInfo.format.duration, out var duration))
+					/*
+					* Trim miliseconds here as we would have done it later anyway.
+					* Reasons are:
+					* - More user friendly
+					* - Allows an improved check against equality
+					* Cons are:
+					* - Not 100% accurate if you consider a difference of e.g. 2 miliseconds makes a duplicate no longer a duplicate
+					* - Breaking change at the moment of implementation as it doesn't apply to already scanned files
+					*/
+					info.Duration = duration.TrimMiliseconds();
+
+				long.TryParse(jsonInfo.format?.bit_rate, out var formatBitrate);
+		
+				for (int i = 0; i < info.Streams.Count(); i++) {
+					var stream = jsonInfo.streams[i];
+					info.Streams[i] = new MediaInfo.StreamInfo();
+					if (stream.bit_rate != null && long.TryParse(stream.bit_rate , out var bitrate))
+						info.Streams[i].BitRate = bitrate;
+					else if (stream.codec_type == "video")
+						info.Streams[i].BitRate = formatBitrate;
+						//Workaround if video stream bitrate is not set but in format
+
+					info.Streams[i].Width 			= stream.width;
+					info.Streams[i].Height 			= stream.height;
+					info.Streams[i].CodecName 		= stream.codec_name ?? "";
+					info.Streams[i].CodecLongName 	= stream.codec_long_name ?? "";
+					info.Streams[i].CodecType 		= stream.codec_type ?? "";
+					info.Streams[i].ChannelLayout 	= stream.channel_layout ?? "";
+					info.Streams[i].PixelFormat 	= stream.pix_fmt ?? "";
+					info.Streams[i].Default			= stream.disposition?.default_ ?? 0;
+					info.Streams[i].Index 			= stream.index.ToString();
+					
+					if (int.TryParse(stream.sample_rate, out var SampleRate))
+						info.Streams[i].SampleRate = SampleRate;
+
+					if (stream.r_frame_rate != null) {
+						if (stream.r_frame_rate.Contains('/')) {
+							var split = stream.r_frame_rate.Split('/');
+							if (split.Length == 2 && int.TryParse(split[0], out var firstRate) && int.TryParse(split[1], out var secondRate))
+								info.Streams[i].FrameRate = (firstRate > 0 && secondRate > 0) ? firstRate / (float)secondRate : -1f;
+						}
+					}
+				}
+			}
+
+			return info;
+		}
+	}
+
+#else
+
+// ---------------------------------------------------------------------------------
+// V2) JSON -> while(){ Read(json); ...} -> Dictionary/List -> MediaInfo class
+// ---------------------------------------------------------------------------------
+
+	static class FFProbeJsonReader {
+
+		static object? ReadJson(ref Utf8JsonReader json, UInt32 max_depth = 5)
+		{
+			if (max_depth == 0)
+				return null;
+			max_depth--;
+
+			if (json.TokenType == JsonTokenType.None)
+				json.Read();
+
+			switch (json.TokenType) {
+				case JsonTokenType.Null:
+					return null;
+				case JsonTokenType.False:
+					return false;
+				case JsonTokenType.True:
+					return true;
+				case JsonTokenType.String:
+					return json.GetString();
+				case JsonTokenType.Number:
+					if (json.TryGetInt32(out var i))
+						return i;
+					if (json.TryGetInt64(out var l))
+						return l;
+					if (json.TryGetDouble(out var d))
+						return d;
+					throw new JsonException(string.Format($"Unsupported number {json.ValueSpan.ToString()}"));
+				case JsonTokenType.StartArray:
+					var list = new List<object>();
+					while (json.Read()) {
+						switch (json.TokenType) {
+							default:
+								var obj = ReadJson(ref json, max_depth);
+								if (obj != null) {
+									list.Add(obj);
+									break;
+								}
+								throw new JsonException();	// null value not allowed
+							case JsonTokenType.EndArray:
+								return list;
+						}
+					}
+					throw new JsonException();
+				case JsonTokenType.StartObject:
+					var dict = new Dictionary<string, object>();
+					while (json.Read()) {
+						switch (json.TokenType) {
+							case JsonTokenType.EndObject:
+								return dict;
+							case JsonTokenType.PropertyName:
+								var key = json.GetString();
+								json.Read();
+								var obj = ReadJson(ref json, max_depth);
+								if (key != null && obj != null) {
+									dict.Add(key, obj);
+									break;
+								}
+								throw new JsonException();	// null key / value not allowed
+							default:
+								throw new JsonException();
+						}
+					}
+					throw new JsonException();
+				default:
+					throw new JsonException(string.Format($"Unknown token {json.TokenType}"));
+			}
+		}
+		
 
 		/// <summary>
 		/// Parses FFprobe JSON output and returns a new <see cref="MediaInfo"/>
@@ -41,91 +217,13 @@ namespace VDF.Core.FFTools {
 		/// <param name="file">The file the JSON output format is about</param>
 		/// <returns><see cref="MediaInfo"/> containing information from FFprobe output</returns>
 		public static MediaInfo Read(byte[] data, string file) {
-
 			var json = new Utf8JsonReader(data, isFinalBlock: false, state: default);
-
-
-			var streams = new List<Dictionary<string, object>>();
-			var format = new Dictionary<string, object>();
-
-			var currentStream = -1;
-
-			var currentObject = JsonObjects.None;
-			string? lastKey = null;
-
-			while (json.Read()) {
-				JsonTokenType tokenType = json.TokenType;
-				ReadOnlySpan<byte> valueSpan = json.ValueSpan;
-				switch (tokenType) {
-				case JsonTokenType.StartObject:
-				case JsonTokenType.EndObject:
-				case JsonTokenType.Null:
-				case JsonTokenType.StartArray:
-				case JsonTokenType.EndArray:
-					break;
-				case JsonTokenType.PropertyName:
-					if (valueSpan.SequenceEqual(StreamsKeyword)) {
-						currentObject = JsonObjects.Streams;
-						break;
-					}
-					if (valueSpan.SequenceEqual(FormatKeyword)) {
-						currentObject = JsonObjects.Format;
-						break;
-					}
-
-					if (valueSpan.SequenceEqual(IndexKeyword)) {
-						streams.Add(new Dictionary<string, object>());
-						currentStream++;
-					}
-
-					if (currentObject == JsonObjects.Streams) {
-						lastKey = json.GetString();
-						if (lastKey != null)
-							streams[currentStream].TryAdd(lastKey, new object());
-					}
-					else if (currentObject == JsonObjects.Format) {
-						lastKey = json.GetString();
-						if (lastKey != null)
-							format.TryAdd(lastKey, new object());
-					}
-					break;
-				case JsonTokenType.String:
-					if (currentObject == JsonObjects.Streams && lastKey != null) {
-						streams[currentStream][lastKey] = json.GetString()!;
-					}
-					else if (currentObject == JsonObjects.Format && lastKey != null) {
-						format[lastKey] = json.GetString()!;
-					}
-					break;
-				case JsonTokenType.Number:
-					if (!json.TryGetInt32(out int valueInteger)) {
-#if DEBUG
-						System.Diagnostics.Trace.TraceWarning($"JSON number parse error: \"{lastKey}\" = {System.Text.Encoding.UTF8.GetString(valueSpan.ToArray())}, file = {file}");
-#endif
-						break;
-					}
-
-					if (currentObject == JsonObjects.Streams && lastKey != null) {
-						streams[currentStream][lastKey] = valueInteger;
-					}
-					else if (currentObject == JsonObjects.Format && lastKey != null) {
-						format[lastKey] = valueInteger;
-					}
-					break;
-				case JsonTokenType.True:
-				case JsonTokenType.False:
-					bool valueBool = json.GetBoolean();
-					if (currentObject == JsonObjects.Streams && lastKey != null) {
-						streams[currentStream][lastKey] = valueBool;
-					}
-					else if (currentObject == JsonObjects.Format && lastKey != null) {
-						format[lastKey] = valueBool;
-					}
-					break;
-				default:
-					throw new ArgumentException();
-				}
-			}
+		
+			//json.Read();
+			DSO root = (DSO)(ReadJson(ref json) ?? new DSO());
+			
+			LO  streams = root.ContainsKey("streams") ? (LO)(root["streams"]) : new LO();
+			DSO format  = root.ContainsKey("format")  ? (DSO)(root["format"]) : new DSO();
 
 			var info = new MediaInfo {
 				Streams = new MediaInfo.StreamInfo[streams.Count]
@@ -143,35 +241,42 @@ namespace VDF.Core.FFTools {
 				 */
 				info.Duration = duration.TrimMiliseconds();
 
-			var foundBitRate = false;
+			long formatBitrate = 0;
+			if (format.ContainsKey("bit_rate"))
+				long.TryParse((string)format["bit_rate"], out formatBitrate);
+
 			for (int i = 0; i < streams.Count; i++) {
 				info.Streams[i] = new MediaInfo.StreamInfo();
-				if (streams[i].ContainsKey("bit_rate") && long.TryParse((string)streams[i]["bit_rate"], out var bitrate)) {
-					foundBitRate = true;
-					info.Streams[i].BitRate = bitrate;
-				}
-				if (streams[i].ContainsKey("width"))
-					info.Streams[i].Width = (int)streams[i]["width"];
-				if (streams[i].ContainsKey("height"))
-					info.Streams[i].Height = (int)streams[i]["height"];
-				if (streams[i].ContainsKey("codec_name"))
-					info.Streams[i].CodecName = (string)streams[i]["codec_name"];
-				if (streams[i].ContainsKey("codec_long_name"))
-					info.Streams[i].CodecLongName = (string)streams[i]["codec_long_name"];
-				if (streams[i].ContainsKey("codec_type"))
-					info.Streams[i].CodecType = (string)streams[i]["codec_type"];
-				if (streams[i].ContainsKey("channel_layout"))
-					info.Streams[i].ChannelLayout = (string)streams[i]["channel_layout"];
+				var stream = (DSO)streams[i];
 
-				if (streams[i].ContainsKey("pix_fmt"))
-					info.Streams[i].PixelFormat = (string)streams[i]["pix_fmt"];
-				if (streams[i].ContainsKey("sample_rate") && int.TryParse((string)streams[i]["sample_rate"], out var sample_rate))
+				if (stream.ContainsKey("width"))
+					info.Streams[i].Width = (int)stream["width"];
+				if (stream.ContainsKey("height"))
+					info.Streams[i].Height = (int)stream["height"];
+				if (stream.ContainsKey("codec_name"))
+					info.Streams[i].CodecName = (string)stream["codec_name"];
+				if (stream.ContainsKey("codec_long_name"))
+					info.Streams[i].CodecLongName = (string)stream["codec_long_name"];
+				if (stream.ContainsKey("codec_type"))
+					info.Streams[i].CodecType = (string)stream["codec_type"];
+				if (stream.ContainsKey("channel_layout"))
+					info.Streams[i].ChannelLayout = (string)stream["channel_layout"];
+
+				if (stream.ContainsKey("pix_fmt"))
+					info.Streams[i].PixelFormat = (string)stream["pix_fmt"];
+				if (stream.ContainsKey("sample_rate") && int.TryParse((string)stream["sample_rate"], out var sample_rate))
 					info.Streams[i].SampleRate = sample_rate;
-				if (streams[i].ContainsKey("index"))
-					info.Streams[i].Index = ((int)streams[i]["index"]).ToString();
+				if (stream.ContainsKey("index"))
+					info.Streams[i].Index = ((int)stream["index"]).ToString();
 
-				if (streams[i].ContainsKey("r_frame_rate")) {
-					var stringFrameRate = (string)streams[i]["r_frame_rate"];
+				if (stream.ContainsKey("bit_rate") && long.TryParse((string)stream["bit_rate"], out var bitrate))
+					info.Streams[i].BitRate = bitrate;
+				else if (info.Streams[i].CodecType == "video")
+					info.Streams[i].BitRate = formatBitrate;
+					//Workaround if video stream bitrate is not set but in format
+
+				if (stream.ContainsKey("r_frame_rate")) {
+					var stringFrameRate = (string)stream["r_frame_rate"];
 					if (stringFrameRate.Contains('/')) {
 						var split = stringFrameRate.Split('/');
 						if (split.Length == 2 && int.TryParse(split[0], out var firstRate) && int.TryParse(split[1], out var secondRate))
@@ -179,12 +284,17 @@ namespace VDF.Core.FFTools {
 					}
 				}
 
+				if (stream.ContainsKey("disposition") && stream["disposition"] != null) {
+					var disposition = (DSO)stream["disposition"];
+					if (disposition.ContainsKey("default"))
+						info.Streams[i].Default = ((int)disposition["default"]);
+				}
 			}
-			//Workaround if video stream bitrate is not set but in format
-			if (!foundBitRate && info.Streams.Length > 0 && format.ContainsKey("bit_rate") && long.TryParse((string)format["bit_rate"], out var formatBitrate))
-				info.Streams[0].BitRate = formatBitrate;
 
 			return info;
 		}
 	}
+
+#endif
+
 }

--- a/VDF.Core/MediaInfo.cs
+++ b/VDF.Core/MediaInfo.cs
@@ -64,6 +64,8 @@ namespace VDF.Core {
 			[ProtoMember(11)]
 			public float FrameRate { get; set; }
 
+			[ProtoMember(12)]
+			public int Default { get; set; }
 		}
 	}
 #pragma warning restore CS8618 // Non-nullable field is uninitialized.

--- a/VDF.Core/ViewModels/DuplicateItem.cs
+++ b/VDF.Core/ViewModels/DuplicateItem.cs
@@ -33,7 +33,8 @@ namespace VDF.Core.ViewModels {
 				bool videoFound = false, audioFound = false;
 
 				for (var i = 0; i < file.mediaInfo.Streams.Length; i++) {
-					if (file.mediaInfo.Streams[i].CodecType.Equals("video", StringComparison.OrdinalIgnoreCase) && !videoFound) {
+					if (file.mediaInfo.Streams[i].CodecType.Equals("video", StringComparison.OrdinalIgnoreCase) &&
+					    (!videoFound || file.mediaInfo.Streams[i].Default != 0)) {
 						Format = file.mediaInfo.Streams[i].CodecName;
 						Fps = file.mediaInfo.Streams[i].FrameRate;
 						BitRateKbs = Math.Round((decimal)file.mediaInfo.Streams[i].BitRate / 1000);
@@ -41,7 +42,8 @@ namespace VDF.Core.ViewModels {
 						FrameSizeInt = file.mediaInfo.Streams[i].Width + file.mediaInfo.Streams[i].Height;
 						videoFound = true;
 					}
-					else if (file.mediaInfo.Streams[i].CodecType.Equals("audio", StringComparison.OrdinalIgnoreCase) && !audioFound) {
+					else if (file.mediaInfo.Streams[i].CodecType.Equals("audio", StringComparison.OrdinalIgnoreCase) &&
+						     (!audioFound || file.mediaInfo.Streams[i].Default != 0)) {
 						AudioFormat = file.mediaInfo.Streams[i].CodecName;
 						AudioChannel = file.mediaInfo.Streams[i].ChannelLayout;
 						AudioSampleRate = file.mediaInfo.Streams[i].SampleRate;

--- a/VDF.Core/ViewModels/DuplicateItem.cs
+++ b/VDF.Core/ViewModels/DuplicateItem.cs
@@ -30,19 +30,22 @@ namespace VDF.Core.ViewModels {
 			GroupId = groupID;
 			if (!file.IsImage && file.mediaInfo?.Streams != null) {
 				Duration = file.mediaInfo.Duration;
+				bool videoFound = false, audioFound = false;
 
 				for (var i = 0; i < file.mediaInfo.Streams.Length; i++) {
-					if (file.mediaInfo.Streams[i].CodecType.Equals("video", StringComparison.OrdinalIgnoreCase)) {
+					if (file.mediaInfo.Streams[i].CodecType.Equals("video", StringComparison.OrdinalIgnoreCase) && !videoFound) {
 						Format = file.mediaInfo.Streams[i].CodecName;
 						Fps = file.mediaInfo.Streams[i].FrameRate;
 						BitRateKbs = Math.Round((decimal)file.mediaInfo.Streams[i].BitRate / 1000);
 						FrameSize = file.mediaInfo.Streams[i].Width + "x" + file.mediaInfo.Streams[i].Height;
 						FrameSizeInt = file.mediaInfo.Streams[i].Width + file.mediaInfo.Streams[i].Height;
+						videoFound = true;
 					}
-					else if (file.mediaInfo.Streams[i].CodecType.Equals("audio", StringComparison.OrdinalIgnoreCase)) {
+					else if (file.mediaInfo.Streams[i].CodecType.Equals("audio", StringComparison.OrdinalIgnoreCase) && !audioFound) {
 						AudioFormat = file.mediaInfo.Streams[i].CodecName;
 						AudioChannel = file.mediaInfo.Streams[i].ChannelLayout;
 						AudioSampleRate = file.mediaInfo.Streams[i].SampleRate;
+						audioFound = true;
 					}
 				}
 


### PR DESCRIPTION
Bugfix for "MKV file: Image resolution used instead of video resolution #137"

If multiple Streams of the same type exists (so e.g. two video streams) VDF displays the media infos of the last stream.
This is probably always or at least often the wrong stream.

In the first commit of this branch I have made only a small change, so VFD uses the first stream of every type for media infos.
(Your `//Workaround if video stream bitrate is not set but in format` also applies the format bitrate to stream 0 only (->`info.Streams[0].BitRate = formatBitrate;`) so my change would fit better to that as well.)

In the second commit I use the default flag of the stream to decide which stream should be used for showing the media infos. 
Since the FFProbeJsonReader was not intended to be easily extended to read a deeper object level, but I need the contents of the inner disposition object, I have rebuilt the reader. Actually there are two variants to choose from. One with JsonSerializer.Deserialize and one based on your variant, which converts the JSON object into a dictionary first.