### PR TITLE
Modified files are detected based on file attributes. If a file has c…

### DIFF
--- a/VDF.Core/FileEntry.cs
+++ b/VDF.Core/FileEntry.cs
@@ -34,6 +34,9 @@ namespace VDF.Core {
 			var extension = fi.Extension;
 			IsImage = FileUtils.ImageExtensions.Any(x => extension.EndsWith(x, StringComparison.OrdinalIgnoreCase));
 			grayBytes = new Dictionary<double, byte[]?>();
+			DateCreated = fi.CreationTimeUtc;
+			DateModified = fi.LastWriteTimeUtc;
+			FileSize = fi.Length;
 		}
 		[ProtoMember(1)]
 		public string Path { get; set; }
@@ -45,6 +48,12 @@ namespace VDF.Core {
 		public MediaInfo? mediaInfo;
 		[ProtoMember(5)]
 		public EntryFlags Flags;
+		[ProtoMember(6)]
+		public DateTime DateCreated;
+		[ProtoMember(7)]
+		public DateTime DateModified;
+		[ProtoMember(8)]
+		public long FileSize;
 
 		[ProtoIgnore]
 		public bool IsImage {

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -134,8 +134,15 @@ namespace VDF.Core {
 				foreach (var file in FileUtils.GetFilesRecursive(path, Settings.IgnoreReadOnlyFolders, Settings.IgnoreHardlinks,
 					Settings.IncludeSubDirectories, Settings.IncludeImages, Settings.BlackList.ToList())) {
 					var fEntry = new FileEntry(file);
-					if (!DatabaseUtils.Database.Contains(fEntry))
+					if (!DatabaseUtils.Database.TryGetValue(fEntry, out var dbEntry))
 						DatabaseUtils.Database.Add(fEntry);
+					else if (fEntry.DateCreated != dbEntry.DateCreated || 
+						    fEntry.DateModified != dbEntry.DateModified || 
+							fEntry.FileSize != dbEntry.FileSize) {
+						// -> Modified or different file
+						DatabaseUtils.Database.Remove(dbEntry);
+						DatabaseUtils.Database.Add(fEntry);
+					}
 				}
 			}
 


### PR DESCRIPTION
 Bugfix: Skipped files and inconsistent recognition because of suboptimal database handling #149 - (4)
> If a video/image is modified or names swapped / renamed to an previous deleted file, VDF still uses the now invalid database thumbnails and so generates wrong results.

Only file size, creation and modification date is compared, so there is no relevant impact on performance.
