### PR TITLE
Selection rules for displayed MediaInfo adapted to the default rules …

### DIFF
--- a/VDF.Core/FFTools/FFProbeJsonReader.cs
+++ b/VDF.Core/FFTools/FFProbeJsonReader.cs
@@ -162,6 +162,8 @@ namespace VDF.Core.FFTools {
 					info.Streams[i].CodecType = (string)streams[i]["codec_type"];
 				if (streams[i].ContainsKey("channel_layout"))
 					info.Streams[i].ChannelLayout = (string)streams[i]["channel_layout"];
+				if (streams[i].ContainsKey("channels"))
+					info.Streams[i].Channels = (int)streams[i]["channels"];
 
 				if (streams[i].ContainsKey("pix_fmt"))
 					info.Streams[i].PixelFormat = (string)streams[i]["pix_fmt"];

--- a/VDF.Core/MediaInfo.cs
+++ b/VDF.Core/MediaInfo.cs
@@ -64,6 +64,8 @@ namespace VDF.Core {
 			[ProtoMember(11)]
 			public float FrameRate { get; set; }
 
+			[ProtoMember(12)]
+			public int Channels { get; set; }
 		}
 	}
 #pragma warning restore CS8618 // Non-nullable field is uninitialized.


### PR DESCRIPTION
As announced in  _Bugfix/wrong metadata_ #152 I changed the selection criteria.
(Bugfix: MKV file: Image resolution used instead of video resolution #137)

Because this has made the reading of the default flag superfluous and thus the original JsonReade can still be used, this  branch has nothing in common with the previous variant, hence the new PR.

Since the audio criterion is based on the channel count, I still had to make a small change to the JsonReader and MediaInfo, because "channels" were not considered so far.
