### PR TITLE
-> Detect and log ffmpeg and ffprobe errors #177

### DIFF
--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -39,7 +39,7 @@ namespace VDF.Core.FFTools {
 				}
 			};
 			string errOut = "";
-			byte[] bytes = null;
+			byte[]? bytes = null;
 			try {
 				process.EnableRaisingEvents = true;
  				process.Start();

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -78,6 +78,7 @@ namespace VDF.Core {
 			Prepare();
 			SearchTimer.Start();
 			ElapsedTimer.Start();
+			Logger.Instance.InsertSeparator('-');
 			Logger.Instance.Info("Building file list...");
 			await BuildFileList();
 			Logger.Instance.Info($"Finished building file list in {SearchTimer.StopGetElapsedAndRestart()}");
@@ -184,9 +185,8 @@ namespace VDF.Core {
 					if (InvalidEntry(entry)) return;
 
 					if (entry.mediaInfo == null && !entry.IsImage) {
-						MediaInfo? info = FFProbeEngine.GetMediaInfo(entry.Path);
+						MediaInfo? info = FFProbeEngine.GetMediaInfo(entry.Path, Settings.ExtendedFFToolsLogging);
 						if (info == null) {
-							Logger.Instance.Info($"ERROR: Failed to retrieve media info from: {entry.Path}");
 							entry.Flags.Set(EntryFlags.MetadataError);
 							return;
 						}
@@ -201,7 +201,7 @@ namespace VDF.Core {
 					if (entry.IsImage && entry.grayBytes.Count == 0)
 						GetGrayBytesFromImage(entry);
 					else if (!entry.IsImage)
-						FfmpegEngine.GetGrayBytesFromVideo(entry, positionList);
+						FfmpegEngine.GetGrayBytesFromVideo(entry, positionList, Settings.ExtendedFFToolsLogging);
 
 					IncrementProgress(entry.Path);
 				});
@@ -340,7 +340,7 @@ namespace VDF.Core {
 									File = entry.Path,
 									Position = TimeSpan.FromSeconds(entry.Duration.TotalSeconds * positionList[j]),
 									GrayScale = 0,
-								});
+								}, Settings.ExtendedFFToolsLogging);
 								if (b == null || b.Length == 0) return;
 								using var byteStream = new MemoryStream(b);
 								var bitmapImage = Image.FromStream(byteStream);

--- a/VDF.Core/Settings.cs
+++ b/VDF.Core/Settings.cs
@@ -38,5 +38,7 @@ namespace VDF.Core {
 		public int ThumbnailCount = 1;
 
 		public int MaxDegreeOfParallelism = 1;
+		
+		public bool ExtendedFFToolsLogging = false;
 	}
 }

--- a/VDF.Core/Utils/Logger.cs
+++ b/VDF.Core/Utils/Logger.cs
@@ -28,6 +28,9 @@ namespace VDF.Core.Utils {
 		public void Info(string text) {
 			LogItemAdded?.Invoke($"{DateTime.Now:HH:mm:ss} => {text}");
 		}
+		public void InsertSeparator(char separatorChar) {
+			LogItemAdded?.Invoke('\n' + new String(separatorChar, 150) + '\n');
+		}
 	}
 
 }

--- a/VDF.GUI/ViewModels/MainWindowViewModel.cs
+++ b/VDF.GUI/ViewModels/MainWindowViewModel.cs
@@ -125,6 +125,12 @@ namespace VDF.GUI.ViewModels {
 			get => _GeneratePreviewThumbnails;
 			set => this.RaiseAndSetIfChanged(ref _GeneratePreviewThumbnails, value);
 		}
+		bool _ExtendedFFToolsLogging = false;
+		public bool ExtendedFFToolsLogging {
+			get => _ExtendedFFToolsLogging;
+			set => this.RaiseAndSetIfChanged(ref _ExtendedFFToolsLogging, value);
+		}
+		
 		string _ScanProgressText;
 		public string ScanProgressText {
 			get => _ScanProgressText;
@@ -267,7 +273,8 @@ namespace VDF.GUI.ViewModels {
 					new XElement("IgnoreReadOnlyFolders", IgnoreReadOnlyFolders),
 					new XElement("UseCuda", UseCuda),
 					new XElement("MaxDegreeOfParallelism", MaxDegreeOfParallelism),
-					new XElement("GeneratePreviewThumbnails", GeneratePreviewThumbnails)
+					new XElement("GeneratePreviewThumbnails", GeneratePreviewThumbnails),
+					new XElement("ExtendedFFToolsLogging", ExtendedFFToolsLogging)
 				)
 			);
 			xDoc.Save(path);
@@ -307,6 +314,9 @@ namespace VDF.GUI.ViewModels {
 			foreach (var n in xDoc.Descendants("IgnoreHardlinks"))
 				if (bool.TryParse(n.Value, out var value))
 					IgnoreHardlinks = value;
+			foreach (var n in xDoc.Descendants("ExtendedFFToolsLogging"))
+				if (bool.TryParse(n.Value, out var value))
+					ExtendedFFToolsLogging = value;	
 		}
 
 		public async void LoadDatabase() {
@@ -553,6 +563,7 @@ namespace VDF.GUI.ViewModels {
 			Scanner.Settings.Percent = Percent;
 			Scanner.Settings.MaxDegreeOfParallelism = MaxDegreeOfParallelism;
 			Scanner.Settings.ThumbnailCount = Thumbnails;
+			Scanner.Settings.ExtendedFFToolsLogging = ExtendedFFToolsLogging;
 			Scanner.Settings.IncludeList.Clear();
 			foreach (var s in Includes)
 				Scanner.Settings.IncludeList.Add(s);

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -693,6 +693,11 @@
                                     Content="Exclude hardlinks"
                                     IsChecked="{Binding IgnoreHardlinks}"
                                     IsThreeState="False" />
+                                <CheckBox
+                                    VerticalAlignment="Center"
+                                    Content="Extended FFTools Logging"
+                                    IsChecked="{Binding ExtendedFFToolsLogging}"
+                                    IsThreeState="False" />
                             </StackPanel>
                             <StackPanel Margin="15,5,0,0" Grid.Column="1">
                                 <TextBlock
@@ -862,7 +867,7 @@
                                 </MenuItem.Header>
                             </MenuItem>
                         </Menu>
-                        <ListBox MinHeight="70"  Grid.Row="1" Items="{Binding LogItems}" Margin="5"/>
+                        <ListBox MinHeight="70"  Grid.Row="1" Items="{Binding LogItems}" Margin="5" ScrollViewer.HorizontalScrollBarVisibility="Visible"/>
                     </Grid>
                 </TabItem>
             </TabControl>


### PR DESCRIPTION
 -> Detect and log ffmpeg and ffprobe errors #177 

- StandardError is redirected
  -  Performing asynchronous read  using ErrorDataReceived + BeginErrorReadLine for the second stream as proposed in c# documentation
  - Added additional WaitForExit() as e.g. mentioned in https://github.com/dotnet/runtime/issues/18789. (Otherwise, I could indeed observe that occasionally messages were missing)
- The additional logging can be enabled by settings (If not desired I can remove it again)
- As it can happen that e.g. GetMediaInfo returns non null but ffprobe returned an error, there is the ERROR vs. WARNING differentiation in the message (*1). 

Additional small extensions:
- Added Logger.InsertSeparator()
- Added horizontal scroll bar to logging Listbox

----------
(*1) If ffprobe can't read the media infos, it returns an empty json object. There is no special handling so this results in returning a non null value. In my opinion GetMediaInfo() should handle it as an error, setting the MetadataError flag. But as the error flags can't be removed by the user there would be no way to read the files again (if not deleting the database).
You had unfortunately never replied to comments about the handling of MetadataError and ThumbnailError,... so I will make a suggestion again in a small PR.