### PR TITLE
Improved (error) flag handling

### DIFF
--- a/VDF.Core/EntryFlags.cs
+++ b/VDF.Core/EntryFlags.cs
@@ -26,9 +26,9 @@ namespace VDF.Core {
 		MetadataError = 8,
 		TooDark = 16,
 
-		AllErrors = ThumbnailError | MetadataError | TooDark
+		AllErrors = ThumbnailError | MetadataError | TooDark,
+		RemovableFlags = ManuallyExcluded| ThumbnailError | MetadataError | TooDark
 	}
-
 	public static class EntryFlagExtensions {
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool Any(this EntryFlags f, EntryFlags checkFlags) => (f & checkFlags) > 0;

--- a/VDF.Core/FFTools/FFProbeJsonReader.cs
+++ b/VDF.Core/FFTools/FFProbeJsonReader.cs
@@ -40,7 +40,7 @@ namespace VDF.Core.FFTools {
 		/// <param name="data">JSON output</param>
 		/// <param name="file">The file the JSON output format is about</param>
 		/// <returns><see cref="MediaInfo"/> containing information from FFprobe output</returns>
-		public static MediaInfo Read(byte[] data, string file) {
+		public static MediaInfo? Read(byte[] data, string file) {
 
 			var json = new Utf8JsonReader(data, isFinalBlock: false, state: default);
 
@@ -126,6 +126,9 @@ namespace VDF.Core.FFTools {
 					throw new ArgumentException();
 				}
 			}
+
+			if (streams.Count == 0 && format.Count == 0)
+				return null;	// -> Empty JSON object, ffprobe failed
 
 			var info = new MediaInfo {
 				Streams = new MediaInfo.StreamInfo[streams.Count]

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -46,7 +46,10 @@ namespace VDF.Core.FFTools {
 					Logger.Instance.Info($"FFmpeg timed out on file '{settings.File}'");
 					throw new Exception();
 				}
-				return ms.ToArray();
+				if (process.ExitCode == 0)
+					return ms.ToArray();
+				else
+					return null;	// t.b.d: + Extended Logging
 			}
 			catch (Exception) {
 				try {

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -188,7 +188,8 @@ namespace VDF.Core {
 						if (info == null) {
 							Logger.Instance.Info($"ERROR: Failed to retrieve media info from: {entry.Path}");
 							entry.Flags.Set(EntryFlags.MetadataError);
-							entry.Flags.Set(EntryFlags.ThumbnailError); // Because of return, so GetGrayBytesFromVideo is not called ...
+							//entry.Flags.Set(EntryFlags.ThumbnailError); // Because of return, so GetGrayBytesFromVideo is not called ...
+							// ^ not consistent when removing ThumbnailError by disabling cuda
 							return;
 						}
 

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -136,6 +136,26 @@
                                         </StackPanel>
                                     </MenuItem.Header>
                                 </MenuItem>
+                                <MenuItem Command="{Binding ResetBlacklistFlagsCommand}">
+                                    <MenuItem.Header>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock
+                                                Margin="5,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Text="Show All Manually Excluded Files Again On Next Search" />
+                                        </StackPanel>
+                                    </MenuItem.Header>
+                                </MenuItem>
+                                <MenuItem Command="{Binding ResetDatabaseErrorFlagsCommand}">
+                                    <MenuItem.Header>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock
+                                                Margin="5,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Text="Process Bad Files Again On Next Search" />
+                                        </StackPanel>
+                                    </MenuItem.Header>
+                                </MenuItem>
                                 <MenuItem Command="{Binding ExportDataBaseToJsonCommand}">
                                     <MenuItem.Header>
                                         <TextBlock

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -18,6 +18,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
 using VDF.GUI.Mvvm;
+using VDF.Core.Utils;
 
 namespace VDF.GUI.Views {
 	public class MainWindow : FluentWindow {
@@ -46,6 +47,7 @@ namespace VDF.GUI.Views {
 
 		void MainWindow_Exit(object sender, ControlledApplicationLifetimeExitEventArgs e) {
 			ApplicationHelpers.MainWindowDataContext.SaveSettings();
+			DatabaseUtils.UnloadDatabase(); // Needed because of delayed actions
 		}
 
 		void MainWindow_Startup(object sender, ControlledApplicationLifetimeStartupEventArgs e) {


### PR DESCRIPTION
This PR should be seen as a basis for discussion. Details such as coding style etc. should be left out of the discussion until it has been clarified whether the goals pursued with the changes are desired.

Conclusion of the goals:
- More flexibility to control if files should be processed again
- Less unnecessary processing of files we can't read

Details:
- The ExitCode of ffmpeg and ffprobe is evaluated and used as failure criteria
- If ffprobe can't get the meta data this will now really cause that the MetadataError is set. (Based on the ExitCode and in addition based on an json object not containing at least one of the two sections. )
  - In the original version GetMediaInfo() only "failed" if a exception occurred e.g. WaitForExit() timeout.
  - In principle one could not return on GetMediaInfo() failure and go on to get the grayBytes. But as we have no Duration in this case we would only get grayBytes from frame 0. So at best several videos without metadata could still be compared "meaningfully". In this case we just would not return on error.
- InvalidEntry() now also filters MetadataError and Thumbnail Errors

As now videos flagged with MetadataError or ThumbnailError are not processed a second time, enabling e.g. incompatible hardware acceleration would result in setting the flags so further searches with disabled acceleration wouldn't process the videos again. This behaviour we also know from the ToDark flag even after the number of thumbnails was changed.
In addition I assume that adding the ManuallyExcluded flag could not be removed.
=> So I added two database actions allowing to remove all the error flags and to remove the ManuallyExcluded from all database entries. In addition when disabling cuda acceleration all ThumbnailError flag are removed automaticity and when changing the number of Thumbnails the ToDark flag is removed. This is done delayed and not while changing the Settings.


(As this branch is based on your master the extended ffmpeg logging is not considered at the moment. So there are only some t.b.d. comments where the additional ExitCode,... should be logged)