### PR TITLE
InputBox based on MessageMox example added and used to rename files

### DIFF
--- a/VDF.GUI/ViewModels/MainWindowViewModel.cs
+++ b/VDF.GUI/ViewModels/MainWindowViewModel.cs
@@ -478,7 +478,7 @@ namespace VDF.GUI.ViewModels {
 			Debug.Assert(fi.Directory != null, "fi.Directory != null");
 			string newName = await InputBoxService.Show("Enter new name", fi.Name, title:"Rename File");
 			if (string.IsNullOrEmpty(newName)) return;
-			newName = fi.DirectoryName + Path.DirectorySeparatorChar + newName;
+			newName = FileUtils.SafePathCombine(fi.DirectoryName, newName);
 			fi.MoveTo(newName);
 			currentItem.ChangePath(newName);
 		});

--- a/VDF.GUI/ViewModels/MainWindowViewModel.cs
+++ b/VDF.GUI/ViewModels/MainWindowViewModel.cs
@@ -476,14 +476,11 @@ namespace VDF.GUI.ViewModels {
 			if (GetDataGrid.SelectedItem is not DuplicateItemViewModel currentItem) return;
 			var fi = new FileInfo(currentItem.ItemInfo.Path);
 			Debug.Assert(fi.Directory != null, "fi.Directory != null");
-			//TODO: Create an input dialog
-			var result = await new SaveFileDialog {
-				Title = "Enter new name",
-				Directory = fi.Directory.FullName
-			}.ShowAsync(ApplicationHelpers.MainWindow);
-			if (string.IsNullOrEmpty(result)) return;
-			fi.MoveTo(result);
-			currentItem.ChangePath(result);
+			string newName = await InputBoxService.Show("Enter new name", fi.Name, title:"Rename File");
+			if (string.IsNullOrEmpty(newName)) return;
+			newName = fi.DirectoryName + Path.DirectorySeparatorChar + newName;
+			fi.MoveTo(newName);
+			currentItem.ChangePath(newName);
 		});
 		public ReactiveCommand<ListBox, Action> RemoveIncludesFromListCommand => ReactiveCommand.Create<ListBox, Action>(lbox => {
 			while (lbox.SelectedItems.Count > 0)

--- a/VDF.GUI/Views/InputBoxView.xaml
+++ b/VDF.GUI/Views/InputBoxView.xaml
@@ -1,0 +1,71 @@
+<Window
+    x:Class="VDF.GUI.Views.InputBoxView"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mvvm="clr-namespace:VDF.GUI.Mvvm;assembly=VDF.GUI"
+    Title="{Binding Title}"
+    MinWidth="400"
+    Width="400"
+    MaxWidth="600"
+    SizeToContent="Height"
+    WindowStartupLocation="CenterOwner">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <TextBlock
+            Grid.Row="0"
+            Margin="10,20,10,0"
+            Text="{Binding Message}"
+            TextWrapping="Wrap" />
+        <TextBox 
+            Grid.Row="1"
+            Margin="10,10,10,20"
+            Text = "{Binding Input}"
+            Watermark="{Binding WaterMark}" />
+        <Grid Grid.Row="2" Margin="5,0,5,5">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+            <Button
+                Grid.Column="1"
+                Width="100"
+                Margin="5"
+                Command="{Binding OKCommand}"
+                Content="OK"
+                IsDefault="{Binding HasOKButton}"
+                IsVisible="{Binding HasOKButton}" />
+            <Button
+                Grid.Column="2"
+                Width="100"
+                Margin="5"
+                Command="{Binding YesCommand}"
+                Content="Yes"
+                IsDefault="{Binding HasYesButton}"
+                IsVisible="{Binding HasYesButton}" />
+            <Button
+                Grid.Column="3"
+                Width="100"
+                Margin="5"
+                Command="{Binding NoCommand}"
+                Content="No"
+                IsCancel="{Binding HasNoButton}"
+                IsVisible="{Binding HasNoButton}" />
+            <Button
+                Grid.Column="4"
+                Width="100"
+                Margin="5"
+                Command="{Binding CancelCommand}"
+                Content="Cancel"
+                IsCancel="{Binding HasCancelButton}"
+                IsVisible="{Binding HasCancelButton}" />
+        </Grid>
+    </Grid>
+</Window>

--- a/VDF.GUI/Views/InputBoxView.xaml.cs
+++ b/VDF.GUI/Views/InputBoxView.xaml.cs
@@ -1,0 +1,116 @@
+// /*
+//     Copyright (C) 2021 0x90d
+//     This file is part of VideoDuplicateFinder
+//     VideoDuplicateFinder is free software: you can redistribute it and/or modify
+//     it under the terms of the GPLv3 as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//     VideoDuplicateFinder is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU General Public License for more details.
+//     You should have received a copy of the GNU General Public License
+//     along with VideoDuplicateFinder.  If not, see <http://www.gnu.org/licenses/>.
+// */
+//
+
+using System;
+using System.Reactive;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ReactiveUI;
+
+namespace VDF.GUI.Views {
+
+	public static class InputBoxService {
+		public static async Task<String> Show(string message, string defaultInput="", string waterMark="", 
+			InputBoxButtons buttons = InputBoxButtons.Ok | InputBoxButtons.Cancel, string title = null) {
+			var dlg = new InputBoxView(message, defaultInput, waterMark, buttons, title) {
+				Icon = ApplicationHelpers.MainWindow.Icon
+			};
+			return await dlg.ShowDialog<String>(ApplicationHelpers.MainWindow);
+		}
+	}
+
+
+	public class InputBoxView : Window {
+
+		public InputBoxView() {
+			//Designer need this
+			InitializeComponent();
+		}
+		public InputBoxView(string message, string defaultInput="", string waterMark="", 
+			InputBoxButtons buttons = InputBoxButtons.Ok | InputBoxButtons.Cancel, string title = null) {
+			DataContext = new InputBoxVM();
+			((InputBoxVM)DataContext).host = this;
+			((InputBoxVM)DataContext).Message = message;
+			((InputBoxVM)DataContext).Input = defaultInput;
+			((InputBoxVM)DataContext).WaterMark = waterMark;
+			if (!string.IsNullOrEmpty(title))
+				((InputBoxVM)DataContext).Title = title;
+			((InputBoxVM)DataContext).HasCancelButton = (buttons & InputBoxButtons.Cancel) != 0;
+			((InputBoxVM)DataContext).HasNoButton = (buttons & InputBoxButtons.No) != 0;
+			((InputBoxVM)DataContext).HasOKButton = (buttons & InputBoxButtons.Ok) != 0;
+			((InputBoxVM)DataContext).HasYesButton = (buttons & InputBoxButtons.Yes) != 0;
+
+			InitializeComponent();
+
+		}
+		private void InitializeComponent() {
+			AvaloniaXamlLoader.Load(this);
+		}
+	}
+
+	[Flags]
+	public enum InputBoxButtons {
+		None = 0,
+		Ok = 1,
+		Cancel = 2,
+		Yes = 4,
+		No = 8
+	}
+
+	public sealed class InputBoxVM : ReactiveObject {
+
+		public InputBoxView host;
+
+		bool _HasOKButton;
+		public bool HasOKButton {
+			get => _HasOKButton;
+			set => this.RaiseAndSetIfChanged(ref _HasOKButton, value);
+		}
+		bool _HasYesButton;
+		public bool HasYesButton {
+			get => _HasYesButton;
+			set => this.RaiseAndSetIfChanged(ref _HasYesButton, value);
+		}
+		bool _HasNoButton;
+		public bool HasNoButton {
+			get => _HasNoButton;
+			set => this.RaiseAndSetIfChanged(ref _HasNoButton, value);
+		}
+		bool _HasCancelButton;
+		public bool HasCancelButton {
+			get => _HasCancelButton;
+			set => this.RaiseAndSetIfChanged(ref _HasCancelButton, value);
+		}
+		public string Message { get; set; }
+		public string Input { get; set; }
+		public string WaterMark { get; set; }
+		public string Title { get; set; } = "Video Duplicate Finder";
+		public ReactiveCommand<Unit, Unit> OKCommand => ReactiveCommand.Create(() => {
+			host.Close(Input);
+		});
+		public ReactiveCommand<Unit, Unit> YesCommand => ReactiveCommand.Create(() => {
+			host.Close(Input);
+		});
+		public ReactiveCommand<Unit, Unit> NoCommand => ReactiveCommand.Create(() => {
+			host.Close(null);
+		});
+		public ReactiveCommand<Unit, Unit> CancelCommand => ReactiveCommand.Create(() => {
+			host.Close(null);
+		});
+	}
+}


### PR DESCRIPTION
Based on your MessageBox I added an InputBox and used it to replace the File Rename ToDo.

MessageBox:
- I also added IsCancel / IsDefault to the corresponding buttons so you can accept / cancel the dialog by pressing Return/Esc. Maybe you would like the behaviour for the MessageBox as well.
- SizeToContent="Height" because if also Width is auto sized, the MinWidth is ignored until you resize the window manually (at least on my system). Furthermore the MaxWidth does not prevent resizing beyond the limit in most cases. (It's only a comment. I assume this is an avalonia issue.)


File Rename:
- In order to test the dialog I used it for file renaming. But possibly some details like title/message or something else is not like you expect.
- The renaming works, the modle/ItemInfo is also updated but the view keeps the old filename. So `ChangePath() -> OnPropertyChanged()`seem not to have the effect of updating the view. 