### PR TITLE
probeing different ffmpeg library paths

### DIFF
--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -31,9 +31,24 @@ namespace VDF.Core.FFTools {
 		public static FFHardwareAccelerationMode HardwareAccelerationMode;
 		public static string CustomFFArguments = string.Empty;
 		public static bool UseNativeBinding;
+		public static bool NativeFFmpegExists = false;
 		static FfmpegEngine() {
 			FFmpegPath = FFToolsUtils.GetPath(FFToolsUtils.FFTool.FFmpeg) ?? string.Empty;
-			ffmpeg.RootPath = Path.GetDirectoryName(FFmpegPath);
+
+			string?[] pathList = new string?[]{Path.GetDirectoryName(FFmpegPath), ffmpeg.RootPath, string.Empty};
+			foreach (string? path in pathList)
+			{
+				if (path != null) {
+					try {
+						ffmpeg.RootPath = path;
+						ffmpeg.GetOrLoadLibrary("avformat");
+						ffmpeg.GetOrLoadLibrary("swscale");
+						NativeFFmpegExists = true;
+						break;
+					}
+					catch {	}
+				}
+			}
 		}
 
 		public static unsafe byte[]? GetThumbnail(FfmpegSettings settings, bool extendedLogging) {

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -79,7 +79,7 @@ namespace VDF.Core {
 
 		public static bool FFmpegExists => !string.IsNullOrEmpty(FfmpegEngine.FFmpegPath);
 		public static bool FFprobeExists => !string.IsNullOrEmpty(FFProbeEngine.FFprobePath);
-		public static bool NativeFFmpegExists => !string.IsNullOrEmpty(FfmpegEngine.FFmpegPath) && File.Exists(Path.Combine(FFmpeg.AutoGen.ffmpeg.RootPath, "avcodec-58.dll"));
+		public static bool NativeFFmpegExists => FfmpegEngine.NativeFFmpegExists;
 
 		public async void StartSearch() {
 			Prepare();


### PR DESCRIPTION
("avformat",.. are elements of FFmpeg.AutoGen FFmpeg.cs LibraryDependenciesMap)
avformat depends on avcodec and avutil; avformat, avcodec and swscale are the libraries needed by avformat_alloc_context(), sws_getContext(),.. but it is not impossible that I have overlooked something else. But as the original implementation only checked avcodec it should be no problem. (Alternatively you could use "avdevice" this lib depends on everything and more)

Of course it would be possible to remove the ScanEngine.NativeFFmpegExists and use FfmpegEngine.NativeFFmpegExists but I wanted to keep the changes to a minimum.