### PR TITLE
InputBox: Auto selection range can be set.

### DIFF
--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -805,7 +805,7 @@ namespace VDF.GUI.ViewModels {
 			if (GetDataGrid.SelectedItem is not DuplicateItemVM currentItem) return;
 			var fi = new FileInfo(currentItem.ItemInfo.Path);
 			Debug.Assert(fi.Directory != null, "fi.Directory != null");
-			string newName = await InputBoxService.Show("Enter new name", fi.Name, title: "Rename File");
+			string newName = await InputBoxService.Show("Enter new name", fi.Name, title: "Rename File", selEnd: -(1 + Path.GetExtension(fi.Name).Length));
 			if (string.IsNullOrEmpty(newName)) return;
 			newName = FileUtils.SafePathCombine(fi.DirectoryName, newName);
 			while (File.Exists(newName)) {

--- a/VDF.GUI/Views/InputBoxView.xaml.cs
+++ b/VDF.GUI/Views/InputBoxView.xaml.cs
@@ -23,8 +23,8 @@ namespace VDF.GUI.Views {
 
 	public static class InputBoxService {
 		public static async Task<String> Show(string message, string defaultInput = "", string waterMark = "",
-			MessageBoxButtons buttons = MessageBoxButtons.Ok | MessageBoxButtons.Cancel, string title = null) {
-			var dlg = new InputBoxView(message, defaultInput, waterMark, buttons, title) {
+			MessageBoxButtons buttons = MessageBoxButtons.Ok | MessageBoxButtons.Cancel, string title = null, int selStart=0, int selEnd =-1) {
+			var dlg = new InputBoxView(message, defaultInput, waterMark, buttons, title, selStart, selEnd) {
 				Icon = ApplicationHelpers.MainWindow.Icon
 			};
 			return await dlg.ShowDialog<String>(ApplicationHelpers.MainWindow);
@@ -38,7 +38,7 @@ namespace VDF.GUI.Views {
 		public InputBoxView() => InitializeComponent();
 
 		public InputBoxView(string message, string defaultInput = "", string waterMark = "",
-			MessageBoxButtons buttons = MessageBoxButtons.Ok | MessageBoxButtons.Cancel, string title = null) {
+			MessageBoxButtons buttons = MessageBoxButtons.Ok | MessageBoxButtons.Cancel, string title = null, int selStart=0, int selEnd =-1) {
 			DataContext = new InputBoxVM();
 			((InputBoxVM)DataContext).host = this;
 			((InputBoxVM)DataContext).Message = message;
@@ -58,7 +58,11 @@ namespace VDF.GUI.Views {
 			if (textBox != null) {
 				textBox.AttachedToVisualTree += (s, e) => {
 					textBox.Focus();
-					textBox.SelectAll();
+					textBox.SelectionStart = selStart;
+					if (selEnd >= 0)
+						textBox.SelectionEnd = selEnd;
+					else
+						textBox.SelectionEnd = defaultInput.Length + 1 + selEnd;
 				};
 			}
 		}


### PR DESCRIPTION
Used to keep file extension not selected when used for renaming.
->  Rename file - Exclude file extension from Prompt? #229 

May not work because of avalonia issues. At least under Linux (Mint) the selection is removed as soon as the focus is set.
(Also with SelectAll() there was already the same problem before)

Not tested under Windows