### PR TITLE
Added custom actions so that the user can define commands to open one or more files

### DIFF
--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -28,6 +28,12 @@ namespace VDF.GUI.Data {
 		[JsonIgnore]
 		public static SettingsFile Instance => instance ??= new SettingsFile();
 
+		public class CustomActionCommands {
+			public string OpenItemInFolder {get; set;} = string.Empty;
+			public string OpenMultipleInFolder {get; set;} = string.Empty;
+			public string OpenItem {get; set;} = string.Empty;
+			public string OpenMultiple {get; set;} = string.Empty;
+		}
 
 		[JsonPropertyName("Includes")]
 		public ObservableCollection<string> Includes { get; set; } = new();
@@ -148,6 +154,9 @@ namespace VDF.GUI.Data {
 			get => _Thumbnails;
 			set => this.RaiseAndSetIfChanged(ref _Thumbnails, value);
 		}
+		[JsonPropertyName("CustomCommands")]
+		public CustomActionCommands CustomCommands {get; set;} = new();
+
 		public static void SaveSettings(string? path = null) {
 			path ??= FileUtils.SafePathCombine(CoreUtils.CurrentFolder, "Settings.json");
 			File.WriteAllText(path, JsonSerializer.Serialize(instance));

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -404,6 +404,7 @@
                                 <DataGrid.KeyBindings>
                                     <KeyBinding Command="{Binding RenameFileCommand}" Gesture="F2"/>
                                     <KeyBinding Command="{Binding ToggleCheckboxCommand}" Gesture="Space"/>
+                                    <KeyBinding Command="{Binding OpenItemsByColIdCommand}" Gesture="Enter"/>
                                     <KeyBinding Command="{Binding DeleteSelectionWithPromptCommand}" Gesture="Delete"/>
                                     <KeyBinding Command="{Binding DeleteSelectionCommand}" Gesture="Shift+Delete"/>
                                     <KeyBinding Command="{Binding DeleteHighlitedCommand}" Gesture="Control+Delete"/>
@@ -700,6 +701,8 @@
                                         </MenuItem>
                                         <MenuItem Header="Selected Group">
                                             <MenuItem Command="{Binding MarkGroupAsNotAMatchCommand}" Header="Mark as 'Not a match'" ToolTip.Tip="Hides this group and exclude it from future scans, except when there is a new duplicate." />
+                                            <MenuItem Command="{Binding OpenGroupCommand}" Header="Open Group" CommandParameter="0" IsVisible="{Binding MultiOpenSupported}"/>
+                                            <MenuItem Command="{Binding OpenGroupCommand}" Header="Open Group In Folder" CommandParameter="1" IsVisible="{Binding MultiOpenInFolderSupported}" />
                                         </MenuItem>
                                     </ContextMenu>
                                 </DataGrid.ContextMenu>
@@ -919,6 +922,22 @@
                                     ToolTip.Tip="Hardware acceleration mode of ffmpeg"
                                     Items="{Binding HardwareAccelerationModes}"
                                     SelectedItem="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=HardwareAccelerationMode}" />
+                                <TextBlock
+                                    VerticalAlignment="Center"
+                                    FontSize="14"
+                                    ToolTip.Tip="Enter your own commands to open single or multiple files."
+                                    Text="Custom Commands:" />
+                                <ComboBox
+                                    Width="200"
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="Enter your own commands to open single or multiple files."
+                                    Items="{Binding CustomCommandList}"
+                                    SelectedItem="{Binding SelectedCustomCommand}"
+                                    />
+                                <TextBox
+                                    VerticalAlignment="Center"
+                                    ToolTip.Tip="E.g.: 'nemo --tabs %f', where '%f' is the placeholder for the file(s)"
+                                    Text="{Binding SelectedCustomCommandValue}" />
                             </StackPanel>
                         </Grid>
                         <Grid


### PR DESCRIPTION
- It will be possible to define your own command lines for the four actions: 
  - Open
  - Open in folder
  - Open multiple 
  - Open multiple in folder

- If setting a custom open / open in folder command, the default open action is replaced.
-> This allowes to select your favourite player or file manager (e.g. with file selection support on linux)
The multi open actions are used to open whole groups or multiple selected files.
(Open multiple in folder -> some file managers like nemo are able to open multiple directories in tabs)

- There will be two new entries in the context menu to open a group (player + in folder)
  - Only visible if the corresponding multi open command is defined

- The DoubleTapped event on the thumbnails will open all selected files (if a multi open command is defined)

- Pressing enter will open the selected file(s)
  - If the thumbnail column is focused, the open command is executed
  - If the filename column is focused, the open in folder command is executed
  - In combination with the modifier keys for row selection the workflow is faster and easier (in my opinion) than always going via the context menu

- Commands:
  - Simple form: `nemo`  -> The selected files are appended
  - Using the placeholder:  `nemo %f --tabs` -> '%f' will be replaced with the selected files
  - _Exampe: Show the selected files in terminal window: `cmd /c "echo %f & pause"`_
  - If execution fails, a logging entry will be created