### PR TITLE
Bugfix, busy indicator - progress bar animation not disabled when idle

### DIFF
--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1111,7 +1111,7 @@
                         MaxWidth="200"
                         BorderBrush="LimeGreen"
                         BorderThickness="10"
-                        IsIndeterminate="True" />
+                        IsIndeterminate="{Binding IsBusy}" />
                     <TextBlock
                         Margin="0,10,0,0"
                         HorizontalAlignment="Center"


### PR DESCRIPTION
via https://github.com/AvaloniaUI/Avalonia/issues/2012

At this moment if you have IsIndeterminate set to true progress bar animation is constantly calculated, even if progress bar is not visible -- which causes non trivial average cpu load while application is idle.

The simplest approach to fix it in this case is to bind IsIndeterminate to the same value that controls visibility of the progress bar.