### PR TITLE
Bugfix, busy indicator - progress bar border coveres whole progress bar

### DIFF
--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1110,7 +1110,8 @@
                     <ProgressBar
                         MaxWidth="200"
                         BorderBrush="LimeGreen"
-                        BorderThickness="10"
+                        BorderThickness="1"
+                        Height="10"
                         IsIndeterminate="{Binding IsBusy}" />
                     <TextBlock
                         Margin="0,10,0,0"


### PR DESCRIPTION
Busy indicator after change:
![image](https://user-images.githubusercontent.com/5477934/148640113-bb248dd3-2eec-4cb8-84a8-50031ace406f.png)

Right now green border covers blue animation bar and no animation is visible.