### PR TITLE
Improve efficiency of preparing list of items to compare;

### DIFF
--- a/VDF.Core/FileEntry.cs
+++ b/VDF.Core/FileEntry.cs
@@ -57,6 +57,9 @@ namespace VDF.Core {
 		public long FileSize;
 
 		[ProtoIgnore]
+		public bool invalid = true;
+
+		[ProtoIgnore]
 		internal bool IsImage {
 			[MethodImpl(MethodImplOptions.AggressiveInlining)]
 			get => Flags.Has(EntryFlags.IsImage);


### PR DESCRIPTION
`InvalidEntryForDuplicateCheck` is rather heavy operation due to processing time of `InvalidEntry`, so at this moment `ScanList.RemoveAll(InvalidEntryForDuplicateCheck);` can take up to 1/3 of whole processing time. I have added cache to FileEntry to keep state of `InvalidEntry` function which is calculated anyway in `GatherInfos` function.

I have also changed approach to generation of `ScanList`, now it creates empty `ScanList`, and add there valid items instead of copying all items from whole Database and removing these out of scope and invalid.

Not sure if it's the best way of dealing with this issue, but it solved the problem for me.