### PR TITLE
Disable default re-scan of failed entries in consecutive scans; Add setting to enable it if needed;

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -221,7 +221,12 @@ namespace VDF.Core {
 					while (pauseTokenSource.IsPaused) Thread.Sleep(50);
 
 					entry.invalid = InvalidEntry(entry);
-					if (entry.invalid) {
+
+					bool skipEntry = false;
+					skipEntry |= entry.invalid;
+					skipEntry |= entry.Flags.Has(EntryFlags.ThumbnailError) && !Settings.AlwaysRetryFailedSampling;
+
+					if (skipEntry) {
 						IncrementProgress(entry.Path);
 						return ValueTask.CompletedTask;
 					}

--- a/VDF.Core/Settings.cs
+++ b/VDF.Core/Settings.cs
@@ -27,6 +27,7 @@ namespace VDF.Core {
 		public bool IncludeSubDirectories = true;
 		public bool IncludeImages = true;
 		public bool ExtendedFFToolsLogging;
+		public bool AlwaysRetryFailedSampling = false;
 		public bool IgnoreBlackPixels;
 		public bool IgnoreWhitePixels;
 		public bool CompareHorizontallyFlipped;

--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -118,6 +118,12 @@ namespace VDF.GUI.Data {
 			get => _ExtendedFFToolsLogging;
 			set => this.RaiseAndSetIfChanged(ref _ExtendedFFToolsLogging, value);
 		}
+		bool _AlwaysRetryFailedSampling = false;
+		[JsonPropertyName("AlwaysRetryFailedSampling")]
+		public bool AlwaysRetryFailedSampling {
+			get => _AlwaysRetryFailedSampling;
+			set => this.RaiseAndSetIfChanged(ref _AlwaysRetryFailedSampling, value);
+		}
 		bool _UseNativeFfmpegBinding;
 		[JsonPropertyName("UseNativeFfmpegBinding")]
 		public bool UseNativeFfmpegBinding {
@@ -219,6 +225,9 @@ namespace VDF.GUI.Data {
 			foreach (var n in xDoc.Descendants("ExtendedFFToolsLogging"))
 				if (bool.TryParse(n.Value, out var value))
 					Instance.ExtendedFFToolsLogging = value;
+			foreach (var n in xDoc.Descendants("AlwaysRetryFailedSampling"))
+				if (bool.TryParse(n.Value, out var value))
+					Instance.AlwaysRetryFailedSampling = value;
 			foreach (var n in xDoc.Descendants("UseNativeFfmpegBinding"))
 				if (bool.TryParse(n.Value, out var value))
 					Instance.UseNativeFfmpegBinding = value;

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -892,6 +892,7 @@ namespace VDF.GUI.ViewModels {
 			Scanner.Settings.MaxDegreeOfParallelism = SettingsFile.Instance.MaxDegreeOfParallelism;
 			Scanner.Settings.ThumbnailCount = SettingsFile.Instance.Thumbnails;
 			Scanner.Settings.ExtendedFFToolsLogging = SettingsFile.Instance.ExtendedFFToolsLogging;
+			Scanner.Settings.AlwaysRetryFailedSampling = SettingsFile.Instance.AlwaysRetryFailedSampling;
 			Scanner.Settings.CustomFFArguments = SettingsFile.Instance.CustomFFArguments;
 			Scanner.Settings.UseNativeFfmpegBinding = SettingsFile.Instance.UseNativeFfmpegBinding;
 			Scanner.Settings.IgnoreBlackPixels = SettingsFile.Instance.IgnoreBlackPixels;

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -838,6 +838,12 @@
                                     IsThreeState="False" />
                                 <CheckBox
                                     VerticalAlignment="Center"
+                                    Content="Always retry failed sampling"
+                                    ToolTip.Tip="If activated scan engine will try to generate thumbprints of failed entries each time it is run. Otherwise consecutive attempt will be taken only after cleanup of the database."
+                                    IsChecked="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=AlwaysRetryFailedSampling}"
+                                    IsThreeState="False" />
+                                <CheckBox
+                                    VerticalAlignment="Center"
                                     Content="Auto backup scan results"
                                     ToolTip.Tip="If activated a backup gets created each time the scan results list gets changed"
                                     IsChecked="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=BackupAfterListChanged}"


### PR DESCRIPTION
At this moment each time scan is run engine will try to sample each previously failed file - for most cases in regular flow situation won't change, it will fail again -- you would have to update ffmpeg in the meantime or other dependencies, so forcing these scans each time is not bringing much value.

In this PR i have added `Always retry failed sampling` option which `If activated scan engine will try to generate thumbprints of failed entries each time it is run. Otherwise consecutive attempt will be taken only after cleanup of the database.`

Something to consider :)