### PR TITLE
Catch (and ignore) spurious System.IO.DirectoryNotFoundException when traversing network shares

### DIFF
--- a/VDF.Core/Utils/FileUtils.cs
+++ b/VDF.Core/Utils/FileUtils.cs
@@ -56,9 +56,15 @@ namespace VDF.Core.Utils {
 			if (ignoreHardLinks)
 				enumerationOptions.AttributesToSkip |= FileAttributes.ReparsePoint;
 
-			var files = Directory.EnumerateFiles(initial, "*", enumerationOptions)
-				.Where(f => (includeImages ? AllExtensions : VideoExtensions)
-				.Any(x => f.EndsWith(x, StringComparison.OrdinalIgnoreCase)));
+			IEnumerable<String> files;
+
+			try {
+				files = Directory.EnumerateFiles(initial, "*", enumerationOptions)
+					.Where(f => (includeImages ? AllExtensions : VideoExtensions)
+					.Any(x => f.EndsWith(x, StringComparison.OrdinalIgnoreCase)));
+			} catch (System.IO.DirectoryNotFoundException) {
+				return new List<String>();
+			}
 
 			if (recursive)
 				files = files.Concat(Directory.EnumerateDirectories(initial, "*", enumerationOptions)


### PR DESCRIPTION
When running Video Duplicate Finder over a group of paths that includes one or more network shares, occasionally a path on the share is inaccessible (permission denied, temporary error on the server, etc.) and this rather unhelpful exception gets thrown as a result (along with the equally unhelpful message `Could not find a part of the path 'blah'`). It's harmless (the right behavior is to simply ignore that directory and its children and move on), but the program crashes because the exception doesn't get handled.

This PR takes care of that. I've been running the program with this change in place for a few days now without incident. Performance and functionality are unchanged, and now it won't crash when a network share acts grumpy.