### PR TITLE
Bump SixLabors.ImageSharp version

### DIFF
--- a/VDF.Core/VDF.Core.csproj
+++ b/VDF.Core/VDF.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FFmpeg.AutoGen" Version="4.4.1" />
     <PackageReference Include="protobuf-net" Version="3.0.101" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4-alpha.0.69" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Stable version has been released on 28 Sep 2021 :) it is resolved to this anyway but just to avoid warnings on build...