### PR TITLE
Rescan action

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -102,8 +102,11 @@ namespace VDF.Core {
 
 		public async void StartCompare() {
 			Logger.Instance.Info("Scan for duplicates...");
-			if (!cancelationTokenSource.IsCancellationRequested)
+			if (!cancelationTokenSource.IsCancellationRequested) {
+				cancelationTokenSource.Cancel();
+				cancelationTokenSource = new CancellationTokenSource();
 				await Task.Run(ScanForDuplicates, cancelationTokenSource.Token);
+			}
 			SearchTimer.Stop();
 			ElapsedTimer.Stop();
 			Logger.Instance.Info($"Finished scanning for duplicates in {SearchTimer.Elapsed}");

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -97,6 +97,10 @@ namespace VDF.Core {
 			Logger.Instance.Info($"Finished gathering and hashing in {SearchTimer.StopGetElapsedAndRestart()}");
 			BuildingHashesDone?.Invoke(this, new EventArgs());
 			DatabaseUtils.SaveDatabase();
+			StartCompare();
+		}
+
+		public async void StartCompare() {
 			Logger.Instance.Info("Scan for duplicates...");
 			if (!cancelationTokenSource.IsCancellationRequested)
 				await Task.Run(ScanForDuplicates, cancelationTokenSource.Token);
@@ -211,6 +215,7 @@ namespace VDF.Core {
 
 		public static Task<bool> LoadDatabase() => Task.Run(DatabaseUtils.LoadDatabase);
 		public static void SaveDatabase() => DatabaseUtils.SaveDatabase();
+		public static void RemoveFromDatabase(FileEntry dbEntry) => DatabaseUtils.Database.Remove(dbEntry);
 
 		public static void BlackListFileEntry(string filePath) => DatabaseUtils.BlacklistFileEntry(filePath);
 

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -49,7 +49,7 @@
                             Grid.Row="0"
                             MinHeight="30"
                             Background="#333333">
-                            <MenuItem Command="{Binding StartScanCommand}" IsVisible="{Binding !IsScanning}">
+                            <MenuItem Command="{Binding StartScanCommand}" CommandParameter="FullScan" IsVisible="{Binding !IsScanning}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Viewbox Width="20" Height="20">
@@ -60,7 +60,22 @@
                                         <TextBlock
                                             Margin="5,0,0,0"
                                             VerticalAlignment="Center"
-                                            Text="Start" />
+                                            Text="Scan" />
+                                    </StackPanel>
+                                </MenuItem.Header>
+                            </MenuItem>
+                             <MenuItem Command="{Binding StartScanCommand}" CommandParameter="CompareOnly" IsVisible="{Binding !IsScanning}" IsEnabled="{Binding IsGathered}">
+                                <MenuItem.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Viewbox Width="20" Height="20">
+                                            <Canvas Width="24" Height="24">
+                                                <Path Data="m19.3809,4.64738l-1.69658,1.69658c-3.12529,-3.12529 -8.21505,-3.12529 -11.34034,0c-3.12529,3.12529 -3.12529,8.21505 0,11.34034c1.518,1.60729 3.57176,2.41094 5.62553,2.41094s4.10753,-0.80365 5.71483,-2.32165c0.71435,-0.71435 0.71435,-1.78588 0,-2.50024s-1.78588,-0.71435 -2.50024,0c-1.69658,1.78588 -4.554,1.69658 -6.33988,0c-0.89294,-0.89294 -1.33941,-2.05376 -1.33941,-3.21459s0.44647,-2.32165 1.33941,-3.12529c1.69658,-1.78588 4.554,-1.78588 6.33988,0l-1.60729,1.60729c-0.53577,0.53577 -0.17859,1.518 0.62505,1.518l5.80411,0c0.53577,0 0.89294,-0.35717 0.89294,-0.89294l0,-5.89341c0,-0.80365 -0.98224,-1.16083 -1.518,-0.62505l-0.00001,0.00001l0.00001,-0.00001z" Fill="Orange" />
+                                            </Canvas>
+                                        </Viewbox>
+                                        <TextBlock
+                                            Margin="5,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Text="Rescan" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>


### PR DESCRIPTION
In case user would like to quickly recompare all results gathered by scan action with different comparison parameters (like percent threshold etc) it is possible with this new action to skip gathering phase and just redo comparison, should increase convenience of finding sweet spots for particular collections. Of course regular full scan needs to be done at least once for this new button to be enabled.

![image](https://user-images.githubusercontent.com/5477934/149668845-c36ce638-d122-4854-8ca4-0cec2a7c53a6.png)