### PR TITLE
Add Rescan action

### DIFF
--- a/VDF.Core/Utils/DatabaseUtils.cs
+++ b/VDF.Core/Utils/DatabaseUtils.cs
@@ -112,13 +112,16 @@ namespace VDF.Core.Utils {
 			Database.Clear();
 			SaveDatabase();
 		}
-
 		internal static void BlacklistFileEntry(string filePath) {
 			if (!Database.TryGetValue(new FileEntry(filePath), out FileEntry? actualValue))
 				return;
 			actualValue.Flags.Set(EntryFlags.ManuallyExcluded);
 		}
-
+		internal static void UpdateFilePath(string newPath, FileEntry dbEntry) {
+			Database.Remove(dbEntry);
+			dbEntry.Path = newPath;
+			Database.Add(dbEntry);
+		}
 		internal static bool ExportDatabaseToJson(string jsonFile, JsonSerializerOptions options) {
 			try {
 				using var stream = File.OpenWrite(jsonFile);

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -49,7 +49,7 @@
                             Grid.Row="0"
                             MinHeight="30"
                             Background="#333333">
-                            <MenuItem Command="{Binding StartScanCommand}" IsVisible="{Binding !IsScanning}">
+                            <MenuItem Command="{Binding StartScanCommand}" CommandParameter="FullScan" IsVisible="{Binding !IsScanning}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <Viewbox Width="20" Height="20">
@@ -60,7 +60,22 @@
                                         <TextBlock
                                             Margin="5,0,0,0"
                                             VerticalAlignment="Center"
-                                            Text="Start" />
+                                            Text="Scan" />
+                                    </StackPanel>
+                                </MenuItem.Header>
+                            </MenuItem>
+                             <MenuItem Command="{Binding StartScanCommand}" CommandParameter="CompareOnly" IsVisible="{Binding !IsScanning}" IsEnabled="{Binding IsReadyToCompare}">
+                                <MenuItem.Header>
+                                    <StackPanel Orientation="Horizontal">
+                                        <Viewbox Width="20" Height="20">
+                                            <Canvas Width="24" Height="24">
+                                                <Path Data="m19.3809,4.64738l-1.69658,1.69658c-3.12529,-3.12529 -8.21505,-3.12529 -11.34034,0c-3.12529,3.12529 -3.12529,8.21505 0,11.34034c1.518,1.60729 3.57176,2.41094 5.62553,2.41094s4.10753,-0.80365 5.71483,-2.32165c0.71435,-0.71435 0.71435,-1.78588 0,-2.50024s-1.78588,-0.71435 -2.50024,0c-1.69658,1.78588 -4.554,1.69658 -6.33988,0c-0.89294,-0.89294 -1.33941,-2.05376 -1.33941,-3.21459s0.44647,-2.32165 1.33941,-3.12529c1.69658,-1.78588 4.554,-1.78588 6.33988,0l-1.60729,1.60729c-0.53577,0.53577 -0.17859,1.518 0.62505,1.518l5.80411,0c0.53577,0 0.89294,-0.35717 0.89294,-0.89294l0,-5.89341c0,-0.80365 -0.98224,-1.16083 -1.518,-0.62505l-0.00001,0.00001l0.00001,-0.00001z" Fill="Orange" />
+                                            </Canvas>
+                                        </Viewbox>
+                                        <TextBlock
+                                            Margin="5,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Text="Rescan" />
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
@@ -912,6 +927,7 @@
                                     VerticalAlignment="Center"
                                     Maximum="100"
                                     Minimum="1"
+                                    ValueChanged="Thumbnails_ValueChanged"
                                     Value="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=Thumbnails}" />
                                 <TextBlock
                                     Margin="0,5,0,0"

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -99,6 +99,8 @@ namespace VDF.GUI.Views {
 			}
 		}
 
+		void Thumbnails_ValueChanged(object? sender, NumericUpDownValueChangedEventArgs e) => ApplicationHelpers.MainWindowDataContext.Thumbnails_ValueChanged(sender, e);
+
 		void MainWindow_Startup(object? sender, ControlledApplicationLifetimeStartupEventArgs e) => ApplicationHelpers.MainWindowDataContext.LoadDatabase();
 
 		void InitializeComponent() => AvaloniaXamlLoader.Load(this);


### PR DESCRIPTION
Feature initially previewed in https://github.com/0x90d/videoduplicatefinder/pull/280

> In case user would like to quickly recompare all results gathered by scan action with different comparison parameters (like percent threshold etc) it is possible with this new action to skip gathering phase and just redo comparison, should increase convenience of finding sweet spots for particular collections. Of course regular full scan needs to be done at least once for this new button to be enabled.

![image](https://user-images.githubusercontent.com/5477934/150619708-368755e3-d4f2-492e-a562-41732a85758e.png)

In the meantime I have fixed few things:
- On change of thumbnail setting - user is informed that full scan will be required, rescan is disabled
- On remove - DB is correctly updated and removed items won't be shown on rescan
- On rename - DB is correctly updated and renamed items will be shown correctly on rescan
- Timers are handled correctly in both scan and rescan actions
- Minor refactoring of `Prepare` function to reflect split of the search action
