### PR TITLE
Hide 'Database' menu during scan

### DIFF
--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -110,7 +110,7 @@
                                     </StackPanel>
                                 </MenuItem.Header>
                             </MenuItem>
-                            <MenuItem>
+                            <MenuItem IsVisible="{Binding !IsScanning}">
                                 <MenuItem.Header>
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock


### PR DESCRIPTION
This menu is rather not needed during scan, also user should not try to interact with DB during this time.