### PR TITLE
Retrieve compatible ffmpeg pixel format for selected hardware acceleration type

### DIFF
--- a/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
+++ b/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
@@ -35,36 +35,6 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			return error;
 		}
 
-		public static unsafe AVPixelFormat GetHWPixelFormat(AVHWDeviceType hwDevice, AVCodec* codec) {
-			const int AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX = 1;
-			AVBufferRef* hwDeviceCtx;
-
-			for (int i = 0; ; i++) {
-				AVCodecHWConfig* hwConfig = ffmpeg.avcodec_get_hw_config(codec, i);
-				if (hwConfig == null) {
-					throw new Exception($"Failed to find compatible pixel format for {hwDevice}");
-				}
-
-				if ((hwConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) == 0 || hwConfig->device_type != hwDevice) {
-					continue;
-				}
-
-				ffmpeg.av_hwdevice_ctx_create(&hwDeviceCtx, hwDevice, null, null, 0);
-				AVHWFramesConstraints* hwConstraints = ffmpeg.av_hwdevice_get_hwframe_constraints(hwDeviceCtx, hwConfig);
-				if (hwConstraints == null) {
-					continue;
-				}
-
-				for (AVPixelFormat* p = hwConstraints->valid_sw_formats; *p != AVPixelFormat.AV_PIX_FMT_NONE; p++) {
-					AVPixelFormat pixelFormat = *p;
-					if (ffmpeg.sws_isSupportedInput(pixelFormat) != 0) {
-						ffmpeg.av_hwframe_constraints_free(&hwConstraints);
-						return pixelFormat;
-					}
-				}
-			}
-		}
-
 		private static bool FindFFmpegLibraryFiles() {
 			try {
 

--- a/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
+++ b/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
@@ -41,6 +41,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			ffmpeg.avcodec_parameters_to_context(_pCodecContext, _pFormatContext->streams[_streamIndex]->codecpar).ThrowExceptionIfError();
 			ffmpeg.avcodec_open2(_pCodecContext, codec, null).ThrowExceptionIfError();
 
+			Codec = codec;
 			CodecName = ffmpeg.avcodec_get_name(codec->id);
 			FrameSize = new Size(_pCodecContext->width, _pCodecContext->height);
 			PixelFormat = _pCodecContext->pix_fmt;
@@ -49,6 +50,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			_pFrame = ffmpeg.av_frame_alloc();
 		}
 
+		public AVCodec* Codec { get; }
 		public string CodecName { get; }
 		public Size FrameSize { get; }
 		public AVPixelFormat PixelFormat { get; }

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -52,13 +52,10 @@ namespace VDF.Core.FFTools {
 						throw new Exception($"Invalid source pixel format");
 
 					Size sourceSize = vsd.FrameSize;
-					AVPixelFormat sourcePixelFormat = HWDevice == AVHWDeviceType.AV_HWDEVICE_TYPE_NONE
-						? vsd.PixelFormat
-						: FFmpegHelper.GetHWPixelFormat(HWDevice, vsd.Codec);
 					Size destinationSize = isGrayByte ? new Size(16, 16) : new Size(100, Convert.ToInt32(sourceSize.Height * (100 / (double)sourceSize.Width)));
 					AVPixelFormat destinationPixelFormat = isGrayByte ? AVPixelFormat.AV_PIX_FMT_GRAY8 : AVPixelFormat.AV_PIX_FMT_BGRA;
 					using var vfc =
-						new VideoFrameConverter(sourceSize, sourcePixelFormat, destinationSize, destinationPixelFormat);
+						new VideoFrameConverter(sourceSize, vsd.PixelFormat, destinationSize, destinationPixelFormat);
 
 					if (!vsd.TryDecodeFrame(out var frame, settings.Position))
 						throw new Exception($"Failed decoding frame at {settings.Position}");

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -54,7 +54,7 @@ namespace VDF.Core.FFTools {
 					Size sourceSize = vsd.FrameSize;
 					AVPixelFormat sourcePixelFormat = HWDevice == AVHWDeviceType.AV_HWDEVICE_TYPE_NONE
 						? vsd.PixelFormat
-						: FFmpegHelper.GetHWPixelFormat(HWDevice);
+						: FFmpegHelper.GetHWPixelFormat(HWDevice, vsd.Codec);
 					Size destinationSize = isGrayByte ? new Size(16, 16) : new Size(100, Convert.ToInt32(sourceSize.Height * (100 / (double)sourceSize.Width)));
 					AVPixelFormat destinationPixelFormat = isGrayByte ? AVPixelFormat.AV_PIX_FMT_GRAY8 : AVPixelFormat.AV_PIX_FMT_BGRA;
 					using var vfc =

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -242,7 +242,7 @@ namespace VDF.GUI.ViewModels {
 			}
 			catch { }
 			Logger.Instance.LogItemAdded += Instance_LogItemAdded;
-			//Ensure items added before GUI was ready will be shown 
+			//Ensure items added before GUI was ready will be shown
 			Instance_LogItemAdded(string.Empty);
 			if (File.Exists(BackupScanResultsFile))
 				ImportScanResultsIncludingThumbnails(BackupScanResultsFile);
@@ -636,7 +636,7 @@ namespace VDF.GUI.ViewModels {
 				if (list != null)
 					foreach (var dupItem in list)
 						Duplicates.Add(dupItem);
-					
+
 				BuildDuplicatesView();
 				IsBusy = false;
 				stream.Close();
@@ -889,10 +889,6 @@ namespace VDF.GUI.ViewModels {
 			}
 			if (SettingsFile.Instance.UseNativeFfmpegBinding && SettingsFile.Instance.HardwareAccelerationMode == Core.FFTools.FFHardwareAccelerationMode.auto) {
 				await MessageBoxService.Show("You cannot use hardware acceleration mode 'auto' with native ffmpeg bindings. Please explicit set a mode or set it to 'none'.");
-				return;
-			}
-			if (SettingsFile.Instance.UseNativeFfmpegBinding && SettingsFile.Instance.HardwareAccelerationMode == Core.FFTools.FFHardwareAccelerationMode.cuda) {
-				await MessageBoxService.Show("You cannot use hardware acceleration mode 'cuda' with native ffmpeg bindings.");
 				return;
 			}
 			if (SettingsFile.Instance.Includes.Count == 0) {


### PR DESCRIPTION
Should close #219

I got some time to check out what's preventing CUDA from working in #219. I noticed that the current code has a hard-coded mapping from hardware device type to pixel format. For `AV_HWDEVICE_TYPE_CUDA` it is mapped to `AV_PIX_FMT_CUDA` which is either wrong or not available in all cases (e.g. not working in my GTX 2070 Super). My code snippet in #219 uses `av_hwdevice_get_hwframe_constraints` to retrieve the actual pixel formats for specific hw device, so in theory that approach should be more robust.

I only have system to test the CUDA use case. Would be nice if someone can test other hardware types.