### PR TITLE
Fix memory leak caused by not freeing the source frame

### DIFF
--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -57,9 +57,10 @@ namespace VDF.Core.FFTools {
 					using var vfc =
 						new VideoFrameConverter(sourceSize, vsd.PixelFormat, destinationSize, destinationPixelFormat);
 
-					if (!vsd.TryDecodeFrame(out var frame, settings.Position))
+					if (!vsd.TryDecodeFrame(out var srcFrame, settings.Position))
 						throw new Exception($"Failed decoding frame at {settings.Position}");
-					AVFrame convertedFrame = vfc.Convert(frame);
+					AVFrame convertedFrame = vfc.Convert(srcFrame);
+					ffmpeg.av_frame_unref(&srcFrame);
 
 					if (isGrayByte) {
 						int length = ffmpeg.av_image_get_buffer_size(destinationPixelFormat, convertedFrame.width,

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -60,7 +60,6 @@ namespace VDF.Core.FFTools {
 					if (!vsd.TryDecodeFrame(out var srcFrame, settings.Position))
 						throw new Exception($"Failed decoding frame at {settings.Position}");
 					AVFrame convertedFrame = vfc.Convert(srcFrame);
-					ffmpeg.av_frame_unref(&srcFrame);
 
 					if (isGrayByte) {
 						int length = ffmpeg.av_image_get_buffer_size(destinationPixelFormat, convertedFrame.width,


### PR DESCRIPTION
When I was fixing the previous issue, I noticed that with ffmpeg native enabled, there is huge memory leak. The problem is very obvious when using higher degree of parallelism (e.g. 4). No memory leak is visible when ffmpeg native is disabled, so most likely the leak happens in the unsafe code.

I traced down the problem to the output `AVFrame` from `vsd.TryDecodeFrame()`. That frame is fed to the converter, but never freed or unrefed afterwards. Onced unrefed, no more memory leak even with parallelism.

According to doc, `AVCodecContext*` should be freed by `avcodec_free_context`. Fixed.

Also changed my previous code to avoid creating unnecessary hw_device_ctx, since one is already present in the `_pCodecContext->hw_device_ctx`.