### PR TITLE
Fix bug where "none" hardware acceleration mode is not selected initially

### DIFF
--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -92,10 +92,18 @@ namespace VDF.GUI.ViewModels {
 			set => this.RaiseAndSetIfChanged(ref _IsPaused, value);
 		}
 #pragma warning disable CA1822 // Mark members as static => It's used by Avalonia binding
-		public IEnumerable<Core.FFTools.FFHardwareAccelerationMode> HardwareAccelerationModes =>
+		public IEnumerable<string> HardwareAccelerationModes =>
 #pragma warning restore CA1822 // Mark members as static
-			Enum.GetValues<Core.FFTools.FFHardwareAccelerationMode>();
-
+			Array.ConvertAll(Enum.GetValues<Core.FFTools.FFHardwareAccelerationMode>(), m => m.ToString());
+		public string SelectedHardwareAccelerationMode {
+			get => SettingsFile.Instance.HardwareAccelerationMode.ToString();
+			set {
+				if (value != null) {
+					SettingsFile.Instance.HardwareAccelerationMode = Enum.Parse<Core.FFTools.FFHardwareAccelerationMode>(value)!;
+					this.RaisePropertyChanged(nameof(SelectedHardwareAccelerationMode));
+				}
+			}
+		}
 		string _ScanProgressText = string.Empty;
 		public string ScanProgressText {
 			get => _ScanProgressText;
@@ -162,7 +170,7 @@ namespace VDF.GUI.ViewModels {
 		}
 		public bool MultiOpenSupported => !string.IsNullOrEmpty(SettingsFile.Instance.CustomCommands.OpenMultiple);
 		public bool MultiOpenInFolderSupported => !string.IsNullOrEmpty(SettingsFile.Instance.CustomCommands.OpenMultipleInFolder);
-		static readonly List<string> _CustomCommandList = typeof(SettingsFile.CustomActionCommands).GetProperties(BindingFlags.Public | BindingFlags.Instance).Select(p => p.Name).ToList();
+		static readonly List<string> _CustomCommandList = typeof(SettingsFile.CustomActionCommands).GetProperties(BindingFlags.Public | BindingFlags.Instance).ToList().ConvertAll(p => p.Name);
 		public List<string> CustomCommandList => _CustomCommandList;
 		PropertyInfo _SelectedCustomCommand = typeof(SettingsFile.CustomActionCommands).GetProperty(_CustomCommandList[0])!;
 		public string SelectedCustomCommand {

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -960,7 +960,7 @@
                                     VerticalAlignment="Center"
                                     ToolTip.Tip="Hardware acceleration mode of ffmpeg"
                                     Items="{Binding HardwareAccelerationModes}"
-                                    SelectedItem="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=HardwareAccelerationMode}" />
+                                    SelectedItem="{Binding SelectedHardwareAccelerationMode}" />
                                 <TextBlock
                                     VerticalAlignment="Center"
                                     FontSize="14"


### PR DESCRIPTION
Fix #292.

As I mentioned, the custom command combo box is fine but the HA mode is not. So tried a few things to see where the difference is. Turns out, it is the type. Only enumerable of string works.

Once switch to string, it's working again. Also according to [this answer](https://stackoverflow.com/a/55624925/153133) `ConvertAll` is better than `Select`, so I used the former.

I'm not sure of those `RaisePropertyChanged` parts. Correct me if wrong.