### PR TITLE
Add webp to list of supported image formats

### DIFF
--- a/VDF.Core/Utils/FileUtils.cs
+++ b/VDF.Core/Utils/FileUtils.cs
@@ -25,7 +25,8 @@ namespace VDF.Core.Utils {
 			".png",
 			".gif",
 			".bmp",
-			".tiff"};
+			".tiff",
+			".webp"};
 		static readonly string[] VideoExtensions = {
 			".mp4",
 			".wmv",


### PR DESCRIPTION
We're using ImageSharp for the images and it has supported it for years.

This is an extremely simple change, but I realised it wasn't scanning my webp images and wanted to fix it. I performed a scan on 81179 webps and while 410 of them failed to generate a thumbnail, that's only 0.005% failure, which I'd say is fair, especially with the application already having trouble generating thumbnails in general.