### PR TITLE
Add Select All Except Oldest selection to GUI

### DIFF
--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -1100,6 +1100,25 @@ namespace VDF.GUI.ViewModels {
 			}
 
 		});
+		public ReactiveCommand<Unit, Unit> SelectAllExceptOldest => ReactiveCommand.Create(() => {
+			HashSet<Guid> blackListGroupID = new();
+
+			foreach (var first in Duplicates) {
+				if (blackListGroupID.Contains(first.ItemInfo.GroupId)) continue; //Dup has been handled already
+				IEnumerable<DuplicateItemVM> l = Duplicates.Where(d => d.EqualsButQuality(first) && !d.ItemInfo.Path.Equals(first.ItemInfo.Path));
+				var dupMods = l as List<DuplicateItemVM> ?? l.ToList();
+				if (!dupMods.Any()) continue;
+
+				dupMods.Add(first);
+				dupMods = dupMods.OrderBy(s => s.ItemInfo.DateCreated).ToList();
+				dupMods[0].Checked = false;
+				for (int i = 1; i < dupMods.Count; i++) {
+					dupMods[i].Checked = true;
+				}
+
+				blackListGroupID.Add(first.ItemInfo.GroupId);
+			}
+		});
 		public ReactiveCommand<Unit, Unit> MarkGroupAsNotAMatchCommand => ReactiveCommand.Create(() => {
 			Dispatcher.UIThread.InvokeAsync(async () => {
 				if (GetDataGrid.SelectedItem is not DuplicateItemVM data) return;

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -314,6 +314,11 @@
                                             <TextBlock VerticalAlignment="Center" Text="Select Lowest Duration / Quality" ToolTip.Tip="Keep longest / Best Quality" />
                                         </MenuItem.Header>
                                     </MenuItem>
+                                    <MenuItem Command="{Binding SelectAllExceptOldest}">
+                                        <MenuItem.Header>
+                                            <TextBlock VerticalAlignment="Center" Text="Select All Except Oldest" ToolTip.Tip="Keep oldest only" />
+                                        </MenuItem.Header>
+                                    </MenuItem>
                                     <MenuItem Command="{Binding CheckCustomCommand}">
                                         <MenuItem.Header>
                                             <TextBlock VerticalAlignment="Center" Text="Select Custom..." />


### PR DESCRIPTION
Add a new menu item to the Selection capability that selects all items in a group except for the oldest determined by DateCreated property on the file. This will be the first of a few additional selection items if this PR is accepted. While there is the custom expression capability, it has very limited functionality. This PR aims to bring an reasonable method of selecting duplicates for a group.