### PR TITLE
Apply filters when executing a delete

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -470,17 +470,13 @@ namespace VDF.Core {
 									isDuplicate = false;
 							}
 							if (isDuplicate && Settings.IgnoreHardLinks  && CoreUtils.IsWindows && entry.FileSize == compItem.FileSize) {
-								List<string> links = HardLinkHelper.GetHardLinks(entry.Path);
-								if (links.Count > 1) {
-									foreach (var link in links) {
+								foreach (var link in HardLinkHelper.GetHardLinks(entry.Path, true))
 										if (compItem.Path == link) {
 											isDuplicate = false;
 											break;
 										}
 									}
 								}
-							}
-						}
 
 						if (isDuplicate) {
 							lock (duplicateDict) {
@@ -728,29 +724,40 @@ namespace VDF.Core {
 		private const int MAX_PATH = 65535; // Max. NTFS path length.
 		#endregion
 		/// <summary>
-		//// Returns the enumeration of hard links for the given *file* as full file paths, which includes the input path itself.
+		/// Checks for hard links on a Windows NTFS drive associated with the given path.
 		/// </summary>
-		public static List<string> GetHardLinks(string filepath) {
+		/// <param name="filepath">Fully qualified path of the file to check for shared hard links</param>
+		/// <param name="ReturnEmptyListIfOnlyOne">Set true, to return populated list only for files having multiple hard links</param>
+		/// <returns>
+		///		Empty list is returned for non-existing path or unsupported path.
+		///		Single hard link paths returns empty list if ReturnEmptyListIfOnlyOne is true. If false, returns single item list.
+		///		For multiple shared hard links, returns list of all the shared hard links.
+		/// </returns>
+		public static List<string> GetHardLinks(string filepath, bool ReturnEmptyListIfOnlyOne = false) {
 			List<string> links = new List<string>();
 			try {
 				Char[] sbPath = new Char[MAX_PATH + 1];
 				uint charCount = (uint)MAX_PATH;
-				GetVolumePathName(filepath, sbPath, (uint)MAX_PATH);
+				GetVolumePathName(filepath, sbPath, (uint)MAX_PATH); // Must use GetVolumePathName, because Path.GetPathRoot fails on a mounted drive on an empty folder.
 				string volume = new string(sbPath).Trim('\0');
 				volume = volume.Substring(0, volume.Length - 1);
+				Array.Clear(sbPath, 0, MAX_PATH); // Reset the array because these API's can leave garbage at the end of the buffer.
 				IntPtr findHandle;
 				if (INVALID_HANDLE_VALUE != (findHandle = FindFirstFileNameW(filepath, 0, ref charCount, sbPath))) {
 					do {
 						links.Add((volume + new string(sbPath)).Trim('\0')); // Add the full path to the result list.
-						charCount = (uint)MAX_PATH; // Prepare for the next FindNextFileNameW() call.
+						charCount = (uint)MAX_PATH;
+						Array.Clear(sbPath, 0, MAX_PATH);
 					} while (FindNextFileNameW(findHandle, ref charCount, sbPath));
 					FindClose(findHandle);
 				}
 			}
 			catch (Exception ex) {
 				Logger.Instance.Info(
-					$"GetHardLinks: Exception, file: {filepath}, reason: {ex.Message}, stacktrace {ex.StackTrace}");
+					  $"GetHardLinks: Exception, file: {filepath}, reason: {ex.Message}");
 			}
+			if (ReturnEmptyListIfOnlyOne && links.Count < 2)
+				links.Clear();
 			return links;
 		}
 	}

--- a/VDF.Core/Settings.cs
+++ b/VDF.Core/Settings.cs
@@ -21,6 +21,7 @@ namespace VDF.Core {
 		public HashSet<string> BlackList { get; } = new HashSet<string>();
 
 		public bool IgnoreReadOnlyFolders;
+		public bool IgnoreHardLinks;
 		public bool IgnoreReparsePoints;
 		public bool GeneratePreviewThumbnails;
 		public bool UseNativeFfmpegBinding;

--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -52,10 +52,11 @@ namespace VDF.GUI.Data {
 			get => _IgnoreReadOnlyFolders;
 			set => this.RaiseAndSetIfChanged(ref _IgnoreReadOnlyFolders, value);
 		}
-		[Obsolete]
-		[JsonPropertyName("IgnoreHardlinks")]
-		public bool IgnoreHardlinks {
-			set => IgnoreReparsePoints = value;
+		bool _IgnoreHardLinks;
+		[JsonPropertyName("IgnoreHardLinks")]
+		public bool IgnoreHardLinks {
+			get => _IgnoreHardLinks;
+			set => this.RaiseAndSetIfChanged(ref _IgnoreHardLinks, value);
 		}
 		bool _IgnoreReparsePoints;
 		[JsonPropertyName("IgnoreReparsePoints")]
@@ -327,9 +328,12 @@ namespace VDF.GUI.Data {
 			foreach (var n in xDoc.Descendants("GeneratePreviewThumbnails"))
 				if (bool.TryParse(n.Value, out var value))
 					Instance.GeneratePreviewThumbnails = value;
-			foreach (var n in xDoc.Descendants("IgnoreHardlinks"))
+			foreach (var n in xDoc.Descendants("IgnoreReparsePoints"))
 				if (bool.TryParse(n.Value, out var value))
 					Instance.IgnoreReparsePoints = value;
+			foreach (var n in xDoc.Descendants("IgnoreHardLinks"))
+				if (bool.TryParse(n.Value, out var value))
+					Instance.IgnoreHardLinks = value;
 			foreach (var n in xDoc.Descendants("ExtendedFFToolsLogging"))
 				if (bool.TryParse(n.Value, out var value))
 					Instance.ExtendedFFToolsLogging = value;

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -874,7 +874,8 @@ namespace VDF.GUI.ViewModels {
 			if (dlgResult != MessageBoxButtons.Yes) return;
 
 			// Apply filters and deselected any duplicate in which no group member is included in the filters
-			if (!string.IsNullOrEmpty(FilterByPath) || FileType.Value != FileTypeFilter.All) {
+			if (!string.IsNullOrEmpty(FilterByPath) || FileType.Value != FileTypeFilter.All ||
+				FilterSimilarityFrom != 0 || FilterSimilarityTo != 100) {
 				string FilterByPath_lwr = FilterByPath.ToLower();
 				HashSet<System.Guid> IncludedGroups = new HashSet<System.Guid>();
 				for (var i = Duplicates.Count - 1; i >= 0; i--) {
@@ -884,11 +885,18 @@ namespace VDF.GUI.ViewModels {
 						if (FileType.Value == FileTypeFilter.Videos && Duplicates[i].ItemInfo.IsImage)
 							continue;
 					}
+					// With the current GUI behavior, this logic needs to be in the second for-loop
+					//if (Duplicates[i].ItemInfo.Similarity < FilterSimilarityFrom ||
+					//	FilterSimilarityTo > Duplicates[i].ItemInfo.Similarity)
+					//	continue;
 					if (string.IsNullOrEmpty(FilterByPath) || Duplicates[i].ItemInfo.Path.ToLower().Contains(FilterByPath_lwr))
 						IncludedGroups.Add(Duplicates[i].ItemInfo.GroupId);
 				}
 				for (var i = Duplicates.Count - 1; i >= 0; i--) {
 					if (!IncludedGroups.Contains(Duplicates[i].ItemInfo.GroupId))
+						Duplicates[i].Checked = false;
+					else if (Duplicates[i].ItemInfo.Similarity < FilterSimilarityFrom ||
+						FilterSimilarityTo < Duplicates[i].ItemInfo.Similarity)
 						Duplicates[i].Checked = false;
 				}
 			}

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1291,10 +1291,10 @@
                                                         ToolTip.Tip="Deactivate to save memory by disabling preview images of duplicates" />
                                                     <CheckBox
                                                         VerticalAlignment="Center"
-                                                        Content="Exclude Hard Links"
+                                                        Content="Exclude Hard Links (Windows Only)"
                                                         IsChecked="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=IgnoreHardLinks}"
                                                         IsThreeState="False"
-                                                        ToolTip.Tip="Ignore duplicate files which share the same hard link" />
+                                                        ToolTip.Tip="Ignore duplicate files which share the same hard link (Windows NTFS Only)" />
                                                     <CheckBox
                                                         VerticalAlignment="Center"
                                                         Content="Exclude Reparse Points"

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1297,6 +1297,12 @@
                                                         ToolTip.Tip="Deactivate to save memory by disabling preview images of duplicates" />
                                                     <CheckBox
                                                         VerticalAlignment="Center"
+                                                        Content="Exclude Hard Links"
+                                                        IsChecked="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=IgnoreHardLinks}"
+                                                        IsThreeState="False"
+                                                        ToolTip.Tip="Ignore duplicate files which share the same hard link" />
+                                                    <CheckBox
+                                                        VerticalAlignment="Center"
                                                         Content="Exclude Reparse Points"
                                                         IsChecked="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=IgnoreReparsePoints}"
                                                         IsThreeState="False"

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -780,12 +780,6 @@
                                             Minimum="0"
                                             Value="{Binding FilterSimilarityTo}" />
                                     </StackPanel>
-                                    <TextBlock
-                                        Grid.Row="1"
-                                        Margin="0,5,0,0"
-                                        VerticalAlignment="Center"
-                                        Foreground="Red"
-                                        Text="Note: Filter is only visual. All action also applies to filtered out items!" />
                                 </Grid>
                                 <LayoutTransformControl Grid.Row="2">
                                     <DataGrid


### PR DESCRIPTION
When I first starting using VDF, I deleted 100's of video's by mistake, because I thought the deletion would only apply to the filtered viewed files. I did not see the note stating filter is only visual.

The change in this pull request is small and would help avoid end users from unintentionally deleting their files.

I know it makes it so you have two different coding sections to maintain, but that's far safer then putting user's files at risk.