### PR TITLE
Fixed handling of file path containing the `#` character.

### DIFF
--- a/VDF.GUI/Utils/PickerDialogUtils.cs
+++ b/VDF.GUI/Utils/PickerDialogUtils.cs
@@ -19,13 +19,37 @@ using Avalonia.Platform.Storage;
 namespace VDF.GUI.Utils {
 	internal static class PickerDialogUtils {
 
+		private static string GetLocalPath(Uri uriPath) {
+			if (uriPath.IsFile) {
+				// The `LocalPath` member of the `Uri` object we got
+				// from `TryGetUri()` might be wrong if the original
+				// path contains the '#' character, or if escape
+				// sequences (e.g. '%61') occur in the path.
+				//
+				// Thus, it's better to use the `OriginalString` member
+				// instead, which contains the correct data on both
+				// Linux and Windows.  However, the `file://` scheme
+				// might be prefixed (e.g. on Linux), so it needs to be
+				// removed if present.
+				// See https://github.com/0x90d/videoduplicatefinder/pull/400
+				string scheme = uriPath.Scheme + Uri.SchemeDelimiter;
+				if (uriPath.OriginalString.StartsWith(scheme)) {
+					return uriPath.OriginalString.Substring(scheme.Length);
+				}
+				else {
+					return uriPath.OriginalString;
+				}
+			}
+			return uriPath.LocalPath;
+		}
+
 		internal static async Task<string?> OpenFilePicker(FilePickerOpenOptions options) {
 			var paths = await ApplicationHelpers.MainWindow.StorageProvider.OpenFilePickerAsync(options);
 
 			if (paths != null &&
 				paths.Count > 0 &&
 				paths[0].TryGetUri(out Uri? uriPath))
-				return uriPath.LocalPath;
+				return GetLocalPath(uriPath);
 
 			return null;
 		}
@@ -33,7 +57,7 @@ namespace VDF.GUI.Utils {
 			var path = await ApplicationHelpers.MainWindow.StorageProvider.SaveFilePickerAsync(options);
 
 			if (path != null && path.TryGetUri(out Uri? uriPath))
-				return uriPath.LocalPath;
+				return GetLocalPath(uriPath);
 
 			return null;
 		}
@@ -46,7 +70,7 @@ namespace VDF.GUI.Utils {
 			List<string> results = new();
 			foreach (var item in paths) {
 				if (item.TryGetUri(out Uri? uriPath))
-					results.Add(uriPath.LocalPath);
+					results.Add(GetLocalPath(uriPath));
 			}
 			return results;
 		}


### PR DESCRIPTION
Fixes #398.

The issue is that the `Uri` object built from a FilePicker result (via `GetTryUri()`) could be incorrectly parsed when the `#` character exists in the path of the file: the part following the character is considered as a `Fragment`. 
Thus, using `LocalPath` leads to an incomplete file path.  For example, for the Uri `file:///path/to/my#folder`, `LocalPath` gives `/path/to/my`.

For more details about the Uri: https://learn.microsoft.com/en-us/dotnet/api/system.uri?view=net-7.0

Note that this behaviour is seen on Linux,  but it seems different on Windows.
