### PR TITLE
Added "Sort by Group Size"

### DIFF
--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -203,6 +203,10 @@ namespace VDF.GUI.ViewModels {
 				DataGridSortDescription.FromComparer(new CheckedGroupsComparer(this), ListSortDirection.Ascending)),
 				new KeyValuePair<string, DataGridSortDescription>("Group Has Selected Items Descending",
 				DataGridSortDescription.FromComparer(new CheckedGroupsComparer(this), ListSortDirection.Descending)),
+				new KeyValuePair<string, DataGridSortDescription>("Group Size Ascending",
+				DataGridSortDescription.FromComparer(new GroupSizeComparer(this), ListSortDirection.Ascending)),
+				new KeyValuePair<string, DataGridSortDescription>("Group Size Descending",
+				DataGridSortDescription.FromComparer(new GroupSizeComparer(this), ListSortDirection.Descending)),
 			};
 			_SortOrder = SortOrders[0];
 		}

--- a/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
@@ -41,14 +41,28 @@ namespace VDF.GUI.ViewModels {
 		}
 		public sealed class GroupSizeComparer : System.Collections.IComparer {
 			readonly MainWindowVM mainVM;
+			private readonly Dictionary<Guid, int> guidMap = new();
 			public GroupSizeComparer(MainWindowVM vm) => mainVM = vm;
 			public int Compare(object? x, object? y) {
 				if (x == null || y == null)
 					return -1;
 				var dupX = (DuplicateItemVM)x;
 				var dupY = (DuplicateItemVM)y;
-				int groupSizeX = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupX.ItemInfo.GroupId).Count();
-				int groupSizeY = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupY.ItemInfo.GroupId).Count();
+				int groupSizeX, groupSizeY;
+				if (guidMap.ContainsKey(dupX.ItemInfo.GroupId)) {
+					groupSizeX = guidMap[dupX.ItemInfo.GroupId];
+				}
+				else {
+					groupSizeX = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupX.ItemInfo.GroupId).Count();
+					guidMap[dupX.ItemInfo.GroupId] = groupSizeX;
+				}
+				if (guidMap.ContainsKey(dupY.ItemInfo.GroupId)) {
+					groupSizeY = guidMap[dupY.ItemInfo.GroupId];
+				}
+				else {
+					groupSizeY = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupY.ItemInfo.GroupId).Count();
+					guidMap[dupY.ItemInfo.GroupId] = groupSizeY;
+				}
 				return groupSizeX.CompareTo(groupSizeY);
 			}
 		}

--- a/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
@@ -39,6 +39,19 @@ namespace VDF.GUI.ViewModels {
 				return xHasChecked.CompareTo(yHasChecked);
 			}
 		}
+		public sealed class GroupSizeComparer : System.Collections.IComparer {
+			readonly MainWindowVM mainVM;
+			public GroupSizeComparer(MainWindowVM vm) => mainVM = vm;
+			public int Compare(object? x, object? y) {
+				if (x == null || y == null)
+					return -1;
+				var dupX = (DuplicateItemVM)x;
+				var dupY = (DuplicateItemVM)y;
+				int groupSizeX = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupX.ItemInfo.GroupId).Count();
+				int groupSizeY = mainVM.Duplicates.Where(a => a.ItemInfo.GroupId == dupY.ItemInfo.GroupId).Count();
+				return groupSizeX.CompareTo(groupSizeY);
+			}
+		}
 		public KeyValuePair<string, FileTypeFilter>[] TypeFilters { get; } = {
 			new KeyValuePair<string, FileTypeFilter>("All",  FileTypeFilter.All),
 			new KeyValuePair<string, FileTypeFilter>("Videos",  FileTypeFilter.Videos),


### PR DESCRIPTION
Feauture: Sort videos according to the size of their group (ascending/descending)

I wanted to add this feature because the larger groups often require a bit more review in my cases, so having them at the top is useful. For some of my scans, the false positives stack up in one big group and this feature could be used to find these groups quicker. My implementation is basically just a small change to the `CheckedGroupsComparer` so if there might be a better way to implement it let me know so I can change it.