### PR TITLE
Custom Expression Builder improvements

### DIFF
--- a/VDF.GUI/ViewModels/ExpressionBuilderVM.cs
+++ b/VDF.GUI/ViewModels/ExpressionBuilderVM.cs
@@ -29,14 +29,16 @@ namespace VDF.GUI.ViewModels {
 			var sb = new StringBuilder();
 
 			var properties = typeof(DuplicateItem).GetProperties(BindingFlags.Public | BindingFlags.Instance);
+			sb.AppendLine("Build a custom expression to select items. Your expression must return a bool: true if the video should be selected, false otherwise.");
+			sb.AppendLine();
 			foreach (var p in properties) {
-				sb.AppendLine($"arg.{nameof(DuplicateItemVM.ItemInfo)}.{p.Name} ({p.PropertyType.Name})");
+				sb.AppendLine($"item.{p.Name} ({p.PropertyType.Name})");
 			}
 			sb.AppendLine();
 			sb.AppendLine();
-			sb.AppendLine($"Example: arg.{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.IsImage)} && arg.{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.SizeLong)} > 3000");
-			sb.AppendLine($"Example: arg.{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.Path)}.Contains(\"imageFolder\")");
-			sb.AppendLine($"Example: arg.{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.Duration)}.Minute > 15");
+			sb.AppendLine($"Example: item.{nameof(DuplicateItem.IsImage)} && arg.{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.SizeLong)} > 3000");
+			sb.AppendLine($"Example: item.{nameof(DuplicateItem.Path)}.Contains(\"imageFolder\")");
+			sb.AppendLine($"Example: item.{nameof(DuplicateItem.Duration)}.Minute > 15");
 			sb.AppendLine("Note: Expression uses 'Dynamic Expresso' library which understands C# syntax");
 
 			AvailableProperties = sb.ToString();

--- a/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
@@ -23,6 +23,7 @@ using DynamicExpresso.Exceptions;
 using ReactiveUI;
 using VDF.Core;
 using VDF.Core.Utils;
+using VDF.Core.ViewModels;
 using VDF.GUI.Data;
 using VDF.GUI.Views;
 
@@ -33,6 +34,7 @@ namespace VDF.GUI.ViewModels {
 			CustomSelectionView dlg = new(string.Empty);
 			dlg.Show(ApplicationHelpers.MainWindow);
 		});
+
 		public ReactiveCommand<Unit, Unit> CheckCustomCommand => ReactiveCommand.CreateFromTask(async () => {
 			ExpressionBuilder dlg = new();
 			((ExpressionBuilderVM)dlg.DataContext!).ExpressionText = SettingsFile.Instance.LastCustomSelectExpression;
@@ -51,10 +53,12 @@ namespace VDF.GUI.ViewModels {
 
 				IEnumerable<DuplicateItemVM> l = Duplicates.Where(a => a.IsVisibleInFilter && a.ItemInfo.GroupId == first.ItemInfo.GroupId);
 				IEnumerable<DuplicateItemVM> matches;
+
 				try {
+					const string shortIdentifier = "item";
 					var interpreter = new Interpreter().
-						ParseAsDelegate<Func<DuplicateItemVM, bool>>(SettingsFile.Instance.LastCustomSelectExpression);
-					matches = l.Where(interpreter);
+						ParseAsDelegate<Func<DuplicateItem, bool>>(SettingsFile.Instance.LastCustomSelectExpression, shortIdentifier);
+					matches = l.Where(arg => interpreter.Invoke(arg.ItemInfo));
 				}
 				catch (ParseException e) {
 					await MessageBoxService.Show($"Failed to parse '{SettingsFile.Instance.LastCustomSelectExpression}': {e}");

--- a/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
@@ -14,6 +14,7 @@
 // */
 //
 
+using System.Drawing.Text;
 using System.Linq;
 using System.Reactive;
 using Avalonia.Platform.Storage;
@@ -48,6 +49,8 @@ namespace VDF.GUI.ViewModels {
 			bool skipIfAllMatches = false;
 			bool userAsked = false;
 
+			const string shortIdentifier = "item";
+
 			foreach (var first in Duplicates) {
 				if (blackListGroupID.Contains(first.ItemInfo.GroupId)) continue; //Dup has been handled already
 
@@ -55,7 +58,6 @@ namespace VDF.GUI.ViewModels {
 				IEnumerable<DuplicateItemVM> matches;
 
 				try {
-					const string shortIdentifier = "item";
 					var interpreter = new Interpreter().
 						ParseAsDelegate<Func<DuplicateItem, bool>>(SettingsFile.Instance.LastCustomSelectExpression, shortIdentifier);
 					matches = l.Where(arg => interpreter.Invoke(arg.ItemInfo));

--- a/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Selection.cs
@@ -14,7 +14,6 @@
 // */
 //
 
-using System.Drawing.Text;
 using System.Linq;
 using System.Reactive;
 using Avalonia.Platform.Storage;


### PR DESCRIPTION
Feature: Turn `arg.ItemInfo` into just `item` in the custom expression builder to make the expressions shorter and more concise. Also add a quick explainer about custom expressions.