### PR TITLE
New feature: Blacklisting the grouping of confirmed non-matching file pairs

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -404,6 +404,7 @@ namespace VDF.Core {
 		}
 
 		void ScanForDuplicates() {
+			Dictionary<string, HashSet<string>> BlacklistDictionary = new();
 			Dictionary<string, DuplicateItem>? duplicateDict = new();
 
 			//Exclude existing database entries which not met current scan settings
@@ -416,6 +417,13 @@ namespace VDF.Core {
 				}
 			}
 
+			Logger.Instance.Info("Initializing blacklist dictionary of confirmed non-matches...");
+			FileInfo blacklistDictionaryFile = new(FileUtils.SafePathCombine(CoreUtils.CurrentFolder, "BlacklistDictionary.json"));
+			if (blacklistDictionaryFile.Exists && blacklistDictionaryFile.Length > 0) {
+				using var stream = new FileStream(blacklistDictionaryFile.FullName, FileMode.Open);
+				BlacklistDictionary = JsonSerializer.Deserialize<Dictionary<string, HashSet<string>>>(stream)!;
+			}
+
 			Logger.Instance.Info($"Scanning for duplicates in {ScanList.Count:N0} files");
 
 			InitProgress(ScanList.Count);
@@ -425,19 +433,26 @@ namespace VDF.Core {
 
 			try {
 				Parallel.For(0, ScanList.Count, new ParallelOptions { CancellationToken = cancelationTokenSource.Token, MaxDegreeOfParallelism = Settings.MaxDegreeOfParallelism }, i => {
-					while (pauseTokenSource.IsPaused) Thread.Sleep(50);
+				while (pauseTokenSource.IsPaused) Thread.Sleep(50);
 
-					FileEntry? entry = ScanList[i];
-					float difference = 0;
-					DuplicateFlags flags = DuplicateFlags.None;
-					bool isDuplicate;
-					Dictionary<double, byte[]?>? flippedGrayBytes = null;
+				FileEntry? entry = ScanList[i];
+				float difference = 0;
+				DuplicateFlags flags = DuplicateFlags.None;
+				bool isDuplicate;
+				Dictionary<double, byte[]?>? flippedGrayBytes = null;
 
-					if (Settings.CompareHorizontallyFlipped)
-						flippedGrayBytes = CreateFlippedGrayBytes(entry);
+				if (Settings.CompareHorizontallyFlipped)
+					flippedGrayBytes = CreateFlippedGrayBytes(entry);
+
+				bool entryHasBlacklist = BlacklistDictionary.TryGetValue(entry.Path, out HashSet<string>? entryBlacklist);
 
 					for (int n = i + 1; n < ScanList.Count; n++) {
 						FileEntry? compItem = ScanList[n];
+
+						// If entry has blacklisted compItem we can't group them at all, so no need to compare (and blacklist is two-way, no need to check mutual blacklisting)
+						if (entryHasBlacklist && entryBlacklist!.Contains(compItem.Path)) {
+							continue;
+						}
 						if (entry.IsImage != compItem.IsImage)
 							continue;
 						if (!entry.IsImage) {
@@ -475,25 +490,111 @@ namespace VDF.Core {
 								bool foundBase = duplicateDict.TryGetValue(entry.Path, out DuplicateItem? existingBase);
 								bool foundComp = duplicateDict.TryGetValue(compItem.Path, out DuplicateItem? existingComp);
 
+								bool compItemHasBlacklist = BlacklistDictionary.TryGetValue(compItem.Path, out HashSet<string>? compItemBlacklist);
+
 								if (foundBase && foundComp) {
 									//this happens with 4+ identical items:
 									//first, 2+ duplicate groups are found independently, they are merged in this branch
 									if (existingBase!.GroupId != existingComp!.GroupId) {
+
+										bool isEntryGroupMemberBlacklistedByCompItem = false;
+										if (compItemHasBlacklist) {
+											isEntryGroupMemberBlacklistedByCompItem = IsBlacklisted(compItemBlacklist!, duplicateDict.Values.Where(c =>
+												c.GroupId == existingBase!.GroupId));
+										}
+
+										bool isCompItemGroupMemberBlacklistedByEntry = false;
+										if (entryHasBlacklist) {
+											isCompItemGroupMemberBlacklistedByEntry = IsBlacklisted(entryBlacklist!, duplicateDict.Values.Where(c =>
+												c.GroupId == existingComp!.GroupId));
+										}
+
+										// if BOTH entry blacklists one of compItem-group's members AND compitem blacklists one of entry-group's members
+										// we cannot merge these groups, nor add entry or compItem to the other's group
+										if (isEntryGroupMemberBlacklistedByCompItem && isCompItemGroupMemberBlacklistedByEntry) {
+											continue;
+										}
+
+										// if entry blacklists one of compItem-group's items
+										// we cannot merge the groups, but potentially move the compItem over to the entry group.
+										if (isEntryGroupMemberBlacklistedByCompItem) {
+											// Not messing with attempting to move item between groups for now
+											continue;
+										}
+
+										// if compItem blacklists one of entry-group's items
+										// we cannot merge the groups, but potentially move the entry over to the compItem group.
+										if (isCompItemGroupMemberBlacklistedByEntry) {
+											// Not messing with attempting to move item between groups for now
+											continue;
+										}
+
+										// if neither item blacklists members of the other's group
+										// but one of entry-group's members blacklists one of compItem-group's members (and thus vice versa)
+										bool isCompItemGroupMemberBlacklistedByEntryGroupMember = false;
+										foreach(DuplicateItem? entryGroupMember in duplicateDict.Values.Where(c =>
+											c.GroupId == existingBase!.GroupId)) {
+
+											bool entryGroupMemberHasBlacklist = BlacklistDictionary.TryGetValue(entryGroupMember.Path, out HashSet<string>? entryGroupMemberBlacklist);
+											if (entryGroupMemberHasBlacklist) {
+												isCompItemGroupMemberBlacklistedByEntryGroupMember = IsBlacklisted(entryGroupMemberBlacklist!, duplicateDict.Values.Where(c =>
+													c.GroupId == existingComp!.GroupId));
+											}
+
+											if (isCompItemGroupMemberBlacklistedByEntryGroupMember) {
+												break;
+											}
+										}
+
+										if (isCompItemGroupMemberBlacklistedByEntryGroupMember) {
+											continue;
+										}
+
+										// else there is no relevant possible blacklisting, merge groups happily
 										Guid groupID = existingComp!.GroupId;
 										foreach (DuplicateItem? dup in duplicateDict.Values.Where(c =>
-											c.GroupId == groupID))
+											c.GroupId == groupID)) {
 											dup.GroupId = existingBase.GroupId;
+										}
+									} else {
+										// Do nothing, we found two items that are already grouped together through previously merging groups
+										// and we can assume that they therefore have passed blacklist checking
+										continue;
 									}
 								}
 								else if (foundBase) {
-									duplicateDict.TryAdd(compItem.Path,
-										new DuplicateItem(compItem, difference, existingBase!.GroupId, flags));
+									// Entry has existing group, compItem does not.
+									// In order to add compItem to entry's group, compItem can't have blacklisted any of the elements in entry's group
+									bool isBlacklisted = false;
+									if (compItemHasBlacklist) {
+										isBlacklisted = IsBlacklisted(compItemBlacklist!, duplicateDict.Values.Where(c =>
+											c.GroupId == existingBase!.GroupId));
+									}
+
+									if (!isBlacklisted) {
+										duplicateDict.TryAdd(compItem.Path,
+											new DuplicateItem(compItem, difference, existingBase!.GroupId, flags));
+									} else {
+										// Not messing with trying to move items between groups for now
+										continue;
+									}
 								}
 								else if (foundComp) {
-									duplicateDict.TryAdd(entry.Path,
-										new DuplicateItem(entry, difference, existingComp!.GroupId, flags));
+									// compItem does have an existing group, entry does not
+									// In order to add entry to compItem's group, entry can't have blacklisted any of the elements in compItem's group
+									bool isBlacklisted = false;
+									if (entryHasBlacklist) {
+										isBlacklisted = IsBlacklisted(entryBlacklist!, duplicateDict.Values.Where(c =>
+											c.GroupId == existingComp!.GroupId));
+									}
+	
+									if (!isBlacklisted) {
+										duplicateDict.TryAdd(entry.Path,
+											new DuplicateItem(entry, difference, existingComp!.GroupId, flags));
+									}
 								}
 								else {
+									// Neither item belongs to group. Create new group to hold the matching items
 									var groupId = Guid.NewGuid();
 									duplicateDict.TryAdd(compItem.Path, new DuplicateItem(compItem, difference, groupId, flags));
 									duplicateDict.TryAdd(entry.Path, new DuplicateItem(entry, difference, groupId, DuplicateFlags.None));
@@ -507,6 +608,16 @@ namespace VDF.Core {
 			catch (OperationCanceledException) { }
 			Duplicates = new HashSet<DuplicateItem>(duplicateDict.Values);
 		}
+
+		private static bool IsBlacklisted(HashSet<string> blacklist, IEnumerable<DuplicateItem> duplicateItems) {
+			foreach (DuplicateItem? dup in duplicateItems) {
+				if (blacklist.Contains(dup.Path)) {
+					return true;
+				}
+			}
+			return false;
+		}
+
 		public async void CleanupDatabase() {
 			await Task.Run(() => {
 				DatabaseUtils.CleanupDatabase();

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -433,18 +433,18 @@ namespace VDF.Core {
 
 			try {
 				Parallel.For(0, ScanList.Count, new ParallelOptions { CancellationToken = cancelationTokenSource.Token, MaxDegreeOfParallelism = Settings.MaxDegreeOfParallelism }, i => {
-				while (pauseTokenSource.IsPaused) Thread.Sleep(50);
+					while (pauseTokenSource.IsPaused) Thread.Sleep(50);
 
-				FileEntry? entry = ScanList[i];
-				float difference = 0;
-				DuplicateFlags flags = DuplicateFlags.None;
-				bool isDuplicate;
-				Dictionary<double, byte[]?>? flippedGrayBytes = null;
+					FileEntry? entry = ScanList[i];
+					float difference = 0;
+					DuplicateFlags flags = DuplicateFlags.None;
+					bool isDuplicate;
+					Dictionary<double, byte[]?>? flippedGrayBytes = null;
 
-				if (Settings.CompareHorizontallyFlipped)
-					flippedGrayBytes = CreateFlippedGrayBytes(entry);
+					if (Settings.CompareHorizontallyFlipped)
+						flippedGrayBytes = CreateFlippedGrayBytes(entry);
 
-				bool entryHasBlacklist = BlacklistDictionary.TryGetValue(entry.Path, out HashSet<string>? entryBlacklist);
+					bool entryHasBlacklist = BlacklistDictionary.TryGetValue(entry.Path, out HashSet<string>? entryBlacklist);
 
 					for (int n = i + 1; n < ScanList.Count; n++) {
 						FileEntry? compItem = ScanList[n];

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1176,9 +1176,17 @@
                                                 </MenuItem>
                                                 <MenuItem Header="Selected Group">
                                                     <MenuItem
-                                                        Command="{Binding MarkGroupAsNotAMatchCommand}"
-                                                        Header="Mark as 'Not a match'"
-                                                        ToolTip.Tip="Hides this group and exclude it from future scans, except when there is a new duplicate." />
+                                                        Command="{Binding MarkGroupItemsAsNotMatchingCommand}"
+                                                        Header="Mark all items in group as 'Not a match' to each other"
+                                                        ToolTip.Tip="Hides this group and flags all items in it as confirmed non-duplicates of the other items in this group. Future scans will not pair any of these items with eachother in the same group(s) anymore." />
+                                                    <MenuItem
+                                                        Command="{Binding MarkSelectedAsNotMatchingCommand}"
+                                                        Header="Mark this item as 'Not a match' to other items in group"
+                                                        ToolTip.Tip="Hides this item and flags it as a confirmed non-duplicate of the other items in this group. Future scans will not pair this item with any of the other items in the same group anymore." />
+                                                    <MenuItem
+                                                        Command="{Binding AlwaysHideExactGroupCommand}"
+                                                        Header="Always hide this exact group from this and future scans"
+                                                        ToolTip.Tip="Hides this exact group and excludes it from future scan results. The group will reappear if there is a new duplicate added to the group." />
                                                     <MenuItem
                                                         Command="{Binding OpenGroupCommand}"
                                                         CommandParameter="0"


### PR DESCRIPTION
**Background**
When dealing with large groups, the likelihood of an item being added to the group grows with the group size. Similarity between false positives tends to create daisy-chains that eventually merges into super-groups.

If we explicitly declare items as "not matching"/"blacklisted", we can break these daisy chains and thus reduce them to smaller groups that are easier to manage. A simple daisy-chain of similar items can looks like this:

A-B-C-D-E-F-G-H

If we declare item D and E not matching, they are forbidden from grouping together and we end up with this group configuration instead:

A-B-C-D
E-F-G-H

**Summary**
Added scan-time blacklisting of the grouping of user-confirmed not-matching file pairs.
The files need to be scanned/rescanned in order to rearrange the already displayed groups after adding to the blacklist,
Tried to add inline comments to explain what each part of the code does.

**Adding to the blacklist**
Added a json file that keeps a dictionary of hashsets, one for each file that has a blacklisted pairing. It creates a two-way set, so you can look up A see that it blacklists B, and you can look up B and see that it blacklists A.

Initially the file does not exist. The entries are created from the right click menu of the scan result. When you right click an item, you find new options in the Selected Group submenu: 
1) To blacklist the selected item from matching with the each of the other items in the group
2) To blacklist each item in the group from matching with each of the other items in the group

When the option is selected, it adds entries to the dictionary file into the corresponding hashsets.

**Using the blacklist**
When scanning/rescanning the files, the duplicate check will run as usual. The difference is that it also reads the blacklist dictionary, and uses some rules when it compares items for similarity.

If it encounters an item with a blacklist, it checks the elements on the list to evaluate whether or not to group the candidate items. I have tried to comment on the logic to make it understandable.

**Blacklisting logic**
When comparing A and B and they are found to be similar:
- If neither is a member of an existing group:
 We create a new group unless they blacklist each other.
- If A is a member of an existing group and B is not:
 We can't add B to the group if there is a blacklist entry between B and one of A's group members (and similar the other way around). 
 Note: We could potentially move A from its existing group into a new group with B, but that means there can be a disconnect inside A's group where an item is not similar to any remaining items. Not implemented.
- If A and B are members of different existing groups: 
 If A blacklists one of B's members AND B blacklists one of A's members, we cannot merge the groups
 If either A blacklists one of B's members OR B blacklists one of A's members, we still cannot merge the groups (again, could move item from one group to another, e.g. because of higher similarity, but not implemented due to complexity).
If neither A nor B blacklists a group member of the other group, but a member of group A blacklists a member of group B, we cannot merge the groups. (Again, could move item from one group to another, but not implemented due to complexity)
