### PR TITLE
Bump project dependencies

### DIFF
--- a/VDF.Core/VDF.Core.csproj
+++ b/VDF.Core/VDF.Core.csproj
@@ -9,7 +9,7 @@
     <InternalsVisibleTo Include="VDF.GUI" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
     <PackageReference Include="protobuf-net" Version="3.2.16" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />

--- a/VDF.Core/VDF.Core.csproj
+++ b/VDF.Core/VDF.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="FFmpeg.AutoGen" Version="6.0.0.2" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
-    <PackageReference Include="protobuf-net" Version="3.2.16" />
+    <PackageReference Include="protobuf-net" Version="3.2.26" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
 

--- a/VDF.GUI/App.xaml
+++ b/VDF.GUI/App.xaml
@@ -2,10 +2,11 @@
     x:Class="VDF.GUI.App"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="clr-namespace:VDF.GUI">
+    xmlns:local="clr-namespace:VDF.GUI"
+    RequestedThemeVariant="Dark">
 
     <Application.Styles>
-        <FluentTheme Mode="Dark" />
+        <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <!--<StyleInclude Source="resm:Avalonia.Controls.DataGrid.Themes.Fluent.xaml?assembly=Avalonia.Controls.DataGrid" />-->
         <StyleInclude Source="/Styles/Styles.xaml" />

--- a/VDF.GUI/Program.cs
+++ b/VDF.GUI/Program.cs
@@ -35,7 +35,6 @@ namespace VDF.GUI {
 			=> AppBuilder.Configure<App>()
 				.UsePlatformDetect()
 				.With(new X11PlatformOptions {  UseDBusFilePicker = false })
-				.With(new Win32PlatformOptions { UseWindowsUIComposition = true })
 				.UseReactiveUI();
 	}
 }

--- a/VDF.GUI/Utils/PickerDialogUtils.cs
+++ b/VDF.GUI/Utils/PickerDialogUtils.cs
@@ -48,16 +48,16 @@ namespace VDF.GUI.Utils {
 
 			if (paths != null &&
 				paths.Count > 0 &&
-				paths[0].TryGetUri(out Uri? uriPath))
-				return GetLocalPath(uriPath);
+				paths[0].TryGetLocalPath() is string uriPath)
+				return uriPath;
 
 			return null;
 		}
 		internal static async Task<string?> SaveFilePicker(FilePickerSaveOptions options) {
 			var path = await ApplicationHelpers.MainWindow.StorageProvider.SaveFilePickerAsync(options);
 
-			if (path != null && path.TryGetUri(out Uri? uriPath))
-				return GetLocalPath(uriPath);
+			if (path != null && path.TryGetLocalPath() is string uriPath)
+				return uriPath;
 
 			return null;
 		}
@@ -69,8 +69,8 @@ namespace VDF.GUI.Utils {
 
 			List<string> results = new();
 			foreach (var item in paths) {
-				if (item.TryGetUri(out Uri? uriPath))
-					results.Add(GetLocalPath(uriPath));
+				if (item.TryGetLocalPath() is string uriPath)
+					results.Add(uriPath);
 			}
 			return results;
 		}

--- a/VDF.GUI/Utils/TreeHelper.cs
+++ b/VDF.GUI/Utils/TreeHelper.cs
@@ -22,9 +22,9 @@ using Avalonia.VisualTree;
 namespace VDF.GUI.Utils {
 	static class TreeHelper {
 
-		static List<T> GetVisualTreeObjects<T>(this IVisual obj) where T : IVisual {
+		static List<T> GetVisualTreeObjects<T>(this Control obj) where T : Control {
 			var objects = new List<T>();
-			foreach (var child in obj.GetVisualChildren()) {
+			foreach (Control child in obj.GetVisualChildren()) {
 				if (child is T requestedType)
 					objects.Add(requestedType);
 				objects.AddRange(child.GetVisualTreeObjects<T>());

--- a/VDF.GUI/VDF.GUI.csproj
+++ b/VDF.GUI/VDF.GUI.csproj
@@ -31,12 +31,12 @@
     <None Remove="Styles\Styles.xaml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.0-preview4" />
+    <PackageReference Include="Avalonia" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.4" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.4" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.2" />
     <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
   </ItemGroup>
   <ItemGroup>

--- a/VDF.GUI/VDF.GUI.csproj
+++ b/VDF.GUI/VDF.GUI.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview4" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview4" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" Version="11.0.0-preview4" />
-    <PackageReference Include="DynamicExpresso.Core" Version="2.13.0" />
+    <PackageReference Include="DynamicExpresso.Core" Version="2.16.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VDF.Core\VDF.Core.csproj" />

--- a/VDF.GUI/ViewModels/CustomSelectionVM.cs
+++ b/VDF.GUI/ViewModels/CustomSelectionVM.cs
@@ -83,7 +83,7 @@ namespace VDF.GUI.ViewModels {
 		[JsonIgnore]
 		public ReactiveCommand<Unit, Unit> SaveCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.SaveFilePicker(new FilePickerSaveOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				DefaultExtension = ".vdfselection",
 				FileTypeChoices = new FilePickerFileType[] {
 					 new FilePickerFileType("Selection File") { Patterns = new string[] { "*.vdfselection" }}}
@@ -100,7 +100,7 @@ namespace VDF.GUI.ViewModels {
 		[JsonIgnore]
 		public ReactiveCommand<Unit, Unit> LoadCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				FileTypeFilter = new FilePickerFileType[] {
 					 new FilePickerFileType("Selection File") { Patterns = new string[] { "*.vdfselection" }}}
 			});

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -37,7 +37,7 @@ namespace VDF.GUI.ViewModels {
 				Thumbnail = ImageUtils.JoinImages(ItemInfo.ImageList)!;
 				Dispatcher.UIThread.Post(() => {
 					this.RaisePropertyChanged(nameof(Thumbnail));
-				}, DispatcherPriority.Layout);
+				}, DispatcherPriority.Render); // DispatcherPriority.Layout was removed in https://github.com/AvaloniaUI/Avalonia/commit/f300a24402afc9f7f3c177e835a0cec10ce52e6c
 			};
 		}
 		public DuplicateItem ItemInfo { get; set; }

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -162,8 +162,7 @@ namespace VDF.GUI.ViewModels {
 			Scanner.ThumbnailsRetrieved += Scanner_ThumbnailsRetrieved;
 			Scanner.DatabaseCleaned += Scanner_DatabaseCleaned;
 			Scanner.FilesEnumerated += Scanner_FilesEnumerated;
-			var assets = AvaloniaLocator.Current.GetService<IAssetLoader>();
-			Scanner.NoThumbnailImage = SixLabors.ImageSharp.Image.Load(assets!.Open(new Uri("avares://VDF.GUI/Assets/icon.png")));
+			Scanner.NoThumbnailImage = SixLabors.ImageSharp.Image.Load(AssetLoader.Open(new Uri("avares://VDF.GUI/Assets/icon.png")));
 
 			try {
 				File.Delete(Path.Combine(CoreUtils.CurrentFolder, "log.txt"));
@@ -346,7 +345,7 @@ namespace VDF.GUI.ViewModels {
 			view = new DataGridCollectionView(Duplicates);
 			view.GroupDescriptions.Add(new DataGridPathGroupDescription($"{nameof(DuplicateItemVM.ItemInfo)}.{nameof(DuplicateItem.GroupId)}"));
 			view.Filter += DuplicatesFilter;
-			GetDataGrid.Items = view;
+			GetDataGrid.ItemsSource = view;
 			TotalDuplicates = Duplicates.Count;
 			TotalDuplicatesSize = Duplicates.Sum(x => x.ItemInfo.SizeLong).BytesToString();
 			TotalSizeRemovedInternal = 0;
@@ -392,7 +391,7 @@ namespace VDF.GUI.ViewModels {
 		});
 		public static ReactiveCommand<Unit, Unit> ImportDataBaseFromJsonCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				FileTypeFilter = new FilePickerFileType[] {
 					 new FilePickerFileType("Json File") { Patterns = new string[] { "*.json" }}}
 			});
@@ -464,7 +463,7 @@ namespace VDF.GUI.ViewModels {
 		});
 		async Task ExportScanResultsIncludingThumbnails(string? path = null) {
 			path ??= await Utils.PickerDialogUtils.SaveFilePicker(new FilePickerSaveOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				DefaultExtension = ".json",
 				FileTypeChoices = new FilePickerFileType[] {
 					 new FilePickerFileType("Scan Results") { Patterns = new string[] { "*.scanresults" }}}
@@ -494,7 +493,7 @@ namespace VDF.GUI.ViewModels {
 		}
 		public ReactiveCommand<Unit, Unit> ImportScanResultsFromFileCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				FileTypeFilter = new FilePickerFileType[] {
 					 new FilePickerFileType("Scan Results") { Patterns = new string[] { "*.scanresults" }}}
 			});
@@ -509,7 +508,7 @@ namespace VDF.GUI.ViewModels {
 
 			if (path == null) {
 				path = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions() {
-					SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+					SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 					FileTypeFilter = new FilePickerFileType[] {
 					 new FilePickerFileType("Scan Results") { Patterns = new string[] { "*.scanresults" }}}
 				});
@@ -951,8 +950,7 @@ namespace VDF.GUI.ViewModels {
 			}
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-			await ((IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard)))
-				   .SetTextAsync(sb.ToString().TrimEnd(new char[2] { '\r', '\n' }));
+			await (ApplicationHelpers.MainWindow.Clipboard.SetTextAsync(sb.ToString().TrimEnd(new char[2] { '\r', '\n' })));
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		});
@@ -964,8 +962,7 @@ namespace VDF.GUI.ViewModels {
 			}
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
-			await ((IClipboard)AvaloniaLocator.Current.GetService(typeof(IClipboard)))
-				   .SetTextAsync(sb.ToString().TrimEnd(new char[2] { '\r', '\n' }));
+			await (ApplicationHelpers.MainWindow.Clipboard.SetTextAsync(sb.ToString().TrimEnd(new char[2] { '\r', '\n' })));
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 		});

--- a/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
@@ -159,7 +159,7 @@ namespace VDF.GUI.ViewModels {
 		});
 		public ReactiveCommand<Unit, Unit> SaveSettingsProfileCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.SaveFilePicker(new FilePickerSaveOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				DefaultExtension = ".json",
 				FileTypeChoices = new FilePickerFileType[] {
 					 new FilePickerFileType("Setting File") { Patterns = new string[] { "*.json" }}}
@@ -175,7 +175,7 @@ namespace VDF.GUI.ViewModels {
 		});
 		public ReactiveCommand<Unit, Unit> LoadSettingsProfileCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions() {
-				SuggestedStartLocation = new BclStorageFolder(CoreUtils.CurrentFolder),
+				SuggestedStartLocation = await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(CoreUtils.CurrentFolder),
 				FileTypeFilter = new FilePickerFileType[] {
 					 new FilePickerFileType("Setting File") { Patterns = new string[] { "*.json", "*.xml" }}}
 			});

--- a/VDF.GUI/Views/CustomSelectionView.xaml
+++ b/VDF.GUI/Views/CustomSelectionView.xaml
@@ -189,7 +189,7 @@
                             Grid.Row="1"
                             MinHeight="70"
                             BorderThickness="1"
-                            Items="{Binding Data.PathContains}"
+                            ItemsSource="{Binding Data.PathContains}"
                             SelectionMode="Multiple" />
                         <TextBlock
                             Grid.Row="2"
@@ -235,7 +235,7 @@
                             Grid.Row="1"
                             MinHeight="70"
                             BorderThickness="1"
-                            Items="{Binding Data.PathNotContains}"
+                            ItemsSource="{Binding Data.PathNotContains}"
                             SelectionMode="Multiple" />
                         <TextBlock
                             Grid.Row="2"

--- a/VDF.GUI/Views/CustomSelectionView.xaml.cs
+++ b/VDF.GUI/Views/CustomSelectionView.xaml.cs
@@ -34,7 +34,7 @@ namespace VDF.GUI.Views {
 				RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
 				Environment.OSVersion.Version.Build >= 22000) {
 				Background = null;
-				TransparencyLevelHint = WindowTransparencyLevel.Mica;
+				TransparencyLevelHint = new List<WindowTransparencyLevel> { WindowTransparencyLevel.Mica };
 				ExtendClientAreaChromeHints = Avalonia.Platform.ExtendClientAreaChromeHints.PreferSystemChrome;
 				if (SettingsFile.Instance.DarkMode)
 					this.FindControl<ExperimentalAcrylicBorder>("ExperimentalAcrylicBorderBackgroundBlack")!.IsVisible = true;

--- a/VDF.GUI/Views/DatabaseViewer.xaml
+++ b/VDF.GUI/Views/DatabaseViewer.xaml
@@ -17,7 +17,7 @@
             <TextBlock Text="Search:" VerticalAlignment="Center"/>
             <TextBox Text="{Binding SearchText}" Margin="10,0,0,0" Grid.Column="1"/>
         </Grid>
-        <controls:DataGrid x:Name="datagridDatabase" Grid.Row="1" Items="{Binding DatabaseFilesView}" AutoGenerateColumns="True">
+        <controls:DataGrid x:Name="datagridDatabase" Grid.Row="1" ItemsSource="{Binding DatabaseFilesView}" AutoGenerateColumns="True">
             <controls:DataGrid.KeyBindings>
                 <KeyBinding Command="{Binding DeleteSelectedEntries}" Gesture="Delete"/>
             </controls:DataGrid.KeyBindings>

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -746,7 +746,7 @@
                                         <ComboBox
                                             MinWidth="150"
                                             Margin="5,0,0,0"
-                                            Items="{Binding SortOrders}"
+                                            ItemsSource="{Binding SortOrders}"
                                             SelectedItem="{Binding SortOrder}">
                                             <ComboBox.ItemTemplate>
                                                 <DataTemplate>
@@ -761,7 +761,7 @@
                                         <ComboBox
                                             MinWidth="150"
                                             Margin="5,0,0,0"
-                                            Items="{Binding TypeFilters}"
+                                            ItemsSource="{Binding TypeFilters}"
                                             SelectedItem="{Binding FileType}">
                                             <ComboBox.ItemTemplate>
                                                 <DataTemplate>
@@ -1470,7 +1470,7 @@
                                                     <ComboBox
                                                         x:Name="ComboboxHardwareAccelerationMode"
                                                         VerticalAlignment="Center"
-                                                        Items="{Binding HardwareAccelerationModes}"
+                                                        ItemsSource="{Binding HardwareAccelerationModes}"
                                                         SelectedItem="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=HardwareAccelerationMode}"
                                                         ToolTip.Tip="Hardware acceleration mode of ffmpeg" />
                                                     <TextBlock
@@ -1480,7 +1480,7 @@
                                                     <ComboBox
                                                         Width="200"
                                                         VerticalAlignment="Center"
-                                                        Items="{Binding CustomCommandList}"
+                                                        ItemsSource="{Binding CustomCommandList}"
                                                         SelectedItem="{Binding SelectedCustomCommand}"
                                                         ToolTip.Tip="Enter your own commands to open single or multiple files." />
                                                     <TextBox
@@ -1559,7 +1559,7 @@
                                                         Grid.Row="1"
                                                         BorderThickness="1"
                                                         DragDrop.AllowDrop="True"
-                                                        Items="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=Includes}" />
+                                                        ItemsSource="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=Includes}" />
                                                 </Grid>
                                                 <TextBlock
                                                     Grid.Row="0"
@@ -1624,7 +1624,7 @@
                                                         Grid.Row="1"
                                                         BorderThickness="1"
                                                         DragDrop.AllowDrop="True"
-                                                        Items="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=Blacklists}" />
+                                                        ItemsSource="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=Blacklists}" />
                                                 </Grid>
                                             </Grid>
                                         </Grid>
@@ -1731,7 +1731,7 @@
                                                 MinHeight="70"
                                                 BorderThickness="1"
                                                 IsEnabled="{Binding #CheckboxFilterByFilePathContains.IsChecked}"
-                                                Items="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=FilePathContainsTexts}" />
+                                                ItemsSource="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=FilePathContainsTexts}" />
                                             <TextBlock Grid.Row="2" Text="Note: Supports the following wildcards: '*' and '?'. The backslash character '\' escapes." />
                                         </Grid>
                                         <CheckBox
@@ -1788,7 +1788,7 @@
                                                 MinHeight="70"
                                                 BorderThickness="1"
                                                 IsEnabled="{Binding #CheckboxFilterByFilePathNotContains.IsChecked}"
-                                                Items="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=FilePathNotContainsTexts}" />
+                                                ItemsSource="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=FilePathNotContainsTexts}" />
                                             <TextBlock Grid.Row="2" Text="Note: Supports the following wildcards: '*' and '?'. The backslash character '\' escapes." />
                                         </Grid>
                                         <!--<TextBox
@@ -1909,7 +1909,7 @@
                                 Grid.Row="1"
                                 MinHeight="70"
                                 Margin="5"
-                                Items="{Binding LogItems}"
+                                ItemsSource="{Binding LogItems}"
                                 ScrollViewer.HorizontalScrollBarVisibility="Visible" />
                         </Grid>
                     </TabItem>

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -22,7 +22,9 @@ using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
+using Avalonia.Platform.Storage;
 using Avalonia.Themes.Fluent;
+using Avalonia.Styling;
 using VDF.GUI.Data;
 using VDF.GUI.Mvvm;
 
@@ -57,7 +59,7 @@ namespace VDF.GUI.Views {
 				RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
 				Environment.OSVersion.Version.Build >= 22000) {
 				Background = null;
-				TransparencyLevelHint = WindowTransparencyLevel.Mica;
+				TransparencyLevelHint = new List<WindowTransparencyLevel> { WindowTransparencyLevel.Mica };
 				ExtendClientAreaChromeHints = Avalonia.Platform.ExtendClientAreaChromeHints.PreferSystemChrome;
 				if (SettingsFile.Instance.DarkMode)
 					this.FindControl<ExperimentalAcrylicBorder>("ExperimentalAcrylicBorderBackgroundBlack")!.IsVisible = true;
@@ -66,7 +68,7 @@ namespace VDF.GUI.Views {
 			}
 
 			if (!SettingsFile.Instance.DarkMode)
-				((FluentTheme)Application.Current!.Styles[0]).Mode = FluentThemeMode.Light;
+				RequestedThemeVariant = ThemeVariant.Light;
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
 				this.FindControl<TextBlock>("TextBlockWindowTitle")!.IsVisible = false;
@@ -112,26 +114,26 @@ namespace VDF.GUI.Views {
 			e.DragEffects &= (DragDropEffects.Copy | DragDropEffects.Link);
 
 			// Only allow if the dragged data contains text or filenames.
-			if (!e.Data.Contains(DataFormats.FileNames))
+			if (!e.Data.Contains(DataFormats.Files))
 				e.DragEffects = DragDropEffects.None;
 		}
 
 		private void DropInclude(object? sender, DragEventArgs e) {
-			if (!e.Data.Contains(DataFormats.FileNames)) return;
+			if (!e.Data.Contains(DataFormats.Files)) return;
 
-			foreach (string file in e.Data.GetFileNames()!) {
-				if (!Directory.Exists(file)) continue;
-				if (!SettingsFile.Instance.Includes.Contains(file))
-					SettingsFile.Instance.Includes.Add(file);
+			foreach (var path in e.Data.GetFiles() ?? Array.Empty<IStorageFolder>()) {
+				if (path is not IStorageFolder) continue;
+				if (!SettingsFile.Instance.Includes.Contains(path.Name))
+					SettingsFile.Instance.Includes.Add(path.Name);
 			}
 		}
 		private void DropBlacklist(object? sender, DragEventArgs e) {
-			if (!e.Data.Contains(DataFormats.FileNames)) return;
+			if (!e.Data.Contains(DataFormats.Files)) return;
 
-			foreach (string file in e.Data.GetFileNames()!) {
-				if (!Directory.Exists(file)) continue;
-				if (!SettingsFile.Instance.Blacklists.Contains(file))
-					SettingsFile.Instance.Blacklists.Add(file);
+			foreach (var path in e.Data.GetFiles() ?? Array.Empty<IStorageFolder>()) {
+				if (path is not IStorageFolder) continue;
+				if (!SettingsFile.Instance.Includes.Contains(path.Name))
+					SettingsFile.Instance.Includes.Add(path.Name);
 			}
 		}
 

--- a/VDF.GUI/Views/ThumbnailComparer.xaml
+++ b/VDF.GUI/Views/ThumbnailComparer.xaml
@@ -49,7 +49,7 @@
                 Grid.Column="0"
                 MaxWidth="100"
                 Background="{DynamicResource SystemControlBackgroundChromeBlackLowBrush}"
-                Items="{Binding Items}">
+                ItemsSource="{Binding Items}">
                 <ListBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel>

--- a/VDF.GUI/Views/ThumbnailComparer.xaml.cs
+++ b/VDF.GUI/Views/ThumbnailComparer.xaml.cs
@@ -33,7 +33,7 @@ namespace VDF.GUI.Views {
 				RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
 				Environment.OSVersion.Version.Build >= 22000) {
 				Background = null;
-				TransparencyLevelHint = WindowTransparencyLevel.Mica;
+				TransparencyLevelHint = new List<WindowTransparencyLevel> { WindowTransparencyLevel.Mica };
 				ExtendClientAreaChromeHints = Avalonia.Platform.ExtendClientAreaChromeHints.PreferSystemChrome;
 				if (SettingsFile.Instance.DarkMode)
 					this.FindControl<ExperimentalAcrylicBorder>("ExperimentalAcrylicBorderBackgroundBlack")!.IsVisible = true;


### PR DESCRIPTION
`VDF.Core`:

- Bump [FFmpeg.AutoGen](https://www.nuget.org/packages/FFmpeg.AutoGen) from `6.0.0` to `6.0.0.2`
- Bump [protobuf-net](https://www.nuget.org/packages/protobuf-net) from `3.2.16` to `3.2.26`

`VDF.GUI`:

- Bump [Avalonia](https://www.nuget.org/packages/Avalonia) from `11.0.0-preview4` to `11.0.4`
- Bump [Avalonia.Controls.DataGrid](https://www.nuget.org/packages/Avalonia.Controls.DataGrid) from `11.0.0-preview4` to `11.0.4`
- Bump [Avalonia.Desktop](https://www.nuget.org/packages/Avalonia.Desktop) from `11.0.0-preview4` to `11.0.4`
- Bump [Avalonia.ReactiveUI](https://www.nuget.org/packages/Avalonia.ReactiveUI) from `11.0.0-preview4` to `11.0.4`
- Bump [Avalonia.Themes.Fluent](https://www.nuget.org/packages/Avalonia.Themes.Fluent) from `11.0.0-preview4` to `11.0.4`
- Bump [Avalonia.Xaml.Behaviors](https://www.nuget.org/packages/Avalonia.Xaml.Behaviors) from `11.0.0-preview4` to `11.0.2`
- Bump [DynamicExpresso.Core](https://www.nuget.org/packages/DynamicExpresso.Core) from `2.13.0` to `2.16.1`

Closes #454 