### PR TITLE
feat: add worst image size field for photo items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ paket-files/
 # Python Tools for Visual Studio (PTVS)
 __pycache__/
 *.pyc
+
+# Project output
+outputFolder

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -634,6 +634,16 @@ namespace VDF.Core {
 			}
 		}
 
+		private static void annotateWorstFrameSize(IEnumerable<DuplicateItem> groupItems) {
+			var worstMatch = groupItems.Last();
+			var reverseItems = groupItems.Reverse();
+			foreach (var otherItem in reverseItems.Skip(1)) {
+				if (otherItem.FrameSizeInt > worstMatch.FrameSizeInt) {
+					worstMatch.IsWorstFrameSize = true;
+				}
+			}
+		}
+
 		void HighlightBestMatches() {
 			HashSet<Guid> blackList = new();
 			foreach (DuplicateItem item in Duplicates) {
@@ -702,6 +712,9 @@ namespace VDF.Core {
 						break;
 					otherItem.IsBestFrameSize = true;
 				}
+
+				annotateWorstFrameSize(groupItems);
+
 				blackList.Add(item.GroupId);
 			}
 		}

--- a/VDF.Core/ViewModels/DuplicateItem.cs
+++ b/VDF.Core/ViewModels/DuplicateItem.cs
@@ -112,6 +112,7 @@ namespace VDF.Core.ViewModels {
 		[JsonInclude]
 		public int FrameSizeInt { get; private set; }
 		public bool IsBestFrameSize { get; set; }
+		public bool IsWorstFrameSize {get; set;}
 		[JsonInclude]
 		public string? Format { get; private set; }
 		[JsonInclude]
@@ -142,6 +143,5 @@ namespace VDF.Core.ViewModels {
 			ThumbnailTimestamps = timeSpans;
 			ThumbnailsUpdated?.Invoke();
 		}
-
 	}
 }


### PR DESCRIPTION
Preface: I've been using this software for years now, thank you for making such a great software for sorting bulk-sized photos and videos - this has helped me in sorting my photos better without managed software (e.g., Mac Photos).

I have a problem: I have many duplicates of photos, and some of them contains thumbnails and resized images (thanks, Mac Photos!). I managed to save all these images, but handling 6k images manually have been a year-long hassle for me. With this I introduce IsWorstFrameSize, which picks only one image item that is the worst image quality, such that:
- it only picks the worst image
- it only picks one
- it does not pick anything if there are many identical photos in a group.

I suppose we can fix the IsBestFrameSize to only choose the one best frame size (and not choose all of them), but for this MR I'm adding a worst image that we can pick and delete images/videos with.

Open for discussion.