### PR TITLE
Update ImageSharp to 3.1.4 (Fixes #516)

### DIFF
--- a/VDF.Core/Utils/GrayBytesUtils.cs
+++ b/VDF.Core/Utils/GrayBytesUtils.cs
@@ -41,12 +41,15 @@ namespace VDF.Core.Utils {
 		public static unsafe byte[]? GetGrayScaleValues(Image original, double darkProcent = 80) {
 			// Lock the bitmap's bits.  
 			using var tempImage = original.CloneAs<Bgra32>();
-			tempImage.TryGetSinglePixelSpan(out var pixelSpan);
-			Span<byte> span = MemoryMarshal.AsBytes(pixelSpan);
+			tempImage.DangerousTryGetSinglePixelMemory(out var pixelSpan);
+			Span<byte> span = MemoryMarshal.AsBytes(pixelSpan.Span);
 
 			byte[] buffer = new byte[GrayByteValueLength];
 			int stride = 0;
-			stride = tempImage.GetPixelRowSpan(0).Length;
+			tempImage.ProcessPixelRows(pixelAccessor =>
+			{
+				stride = pixelAccessor.GetRowSpan(0).Length;
+			}); 
 			int bytes = stride * original.Height;
 
 			int count = 0, all = original.Width * original.Height;

--- a/VDF.Core/VDF.Core.csproj
+++ b/VDF.Core/VDF.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FFmpeg.AutoGen" Version="7.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
     <PackageReference Include="protobuf-net" Version="3.2.26" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
   </ItemGroup>
 
 </Project>

--- a/VDF.Core/VDF.Core.csproj
+++ b/VDF.Core/VDF.Core.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="FFmpeg.AutoGen" Version="7.0.0" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1-preview" />
     <PackageReference Include="protobuf-net" Version="3.2.26" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This reverts commit cd0f2959f218f57fed82f57a0d57c467440c501c.

From my testing over the last 2 years of reverting this commit, everything works perfect with it, and it allows for webp's to be scanned properly. 