### PR TITLE
Better support for hardlink detection

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -438,6 +438,9 @@ namespace VDF.Core {
 
 			//Exclude existing database entries which not met current scan settings
 			List<FileEntry> ScanList = new();
+			var includedPathsArr = new String[Settings.IncludeList.Count];
+			Settings.IncludeList.CopyTo(includedPathsArr);
+			var includedPaths = includedPathsArr.ToList();
 
 			Logger.Instance.Info("Prepare list of items to compare...");
 			foreach (FileEntry entry in DatabaseUtils.Database) {
@@ -493,7 +496,7 @@ namespace VDF.Core {
 							entry.FileSize == compItem.FileSize &&
 							entry.mediaInfo!.Duration == compItem.mediaInfo!.Duration &&
 							Settings.ExcludeHardLinks) {
-							foreach (var link in HardLinkUtils.GetHardLinks(entry.Path))
+							foreach (var link in HardLinkUtils.GetHardLinks(includedPaths, entry.Path))
 								if (compItem.Path == link) {
 									isDuplicate = false;
 									break;


### PR DESCRIPTION
The previous approach for linux was scanning the root of the given file: /home/user/files/video_file1.mp4 => scanned: => / for all files

With a 30 second timeout generally would never complete before timing out. And if it did complete, it was scanning the entire filesystem for every single possible duplicate.

Now the scan will occur multiple times but only at the base of each included directory:
IncludeDir: /home/user1/files
IncludeDir: /home/user2/videos/
Scans => /home/user1/files/ and /home/user2/videos/

Ideally, I think the hard links approach for linux should simply collect all inode values at the start of file enumeration (st_ino) and use those for comparison (without even invoking ffmpeg or any other heuristics) since the inode number is the definition of hard-links (for linux), but that approach requires modifying the FileEntry struct which involves protobuf attributes and I'm not really familiar with that.