### PR TITLE
Track inodes and use them for hard link comparisons on linux

### DIFF
--- a/VDF.Core/FileEntry.cs
+++ b/VDF.Core/FileEntry.cs
@@ -38,6 +38,14 @@ namespace VDF.Core {
 			DateCreated = fileInfo.CreationTimeUtc;
 			DateModified = fileInfo.LastWriteTimeUtc;
 			FileSize = fileInfo.Length;
+			if (CoreUtils.IsWindows) {
+				Inode = 0;
+			} else {
+				var ok = Mono.Unix.Native.Syscall.stat(_Path, out var stat);
+				if (ok == 0) {
+					Inode = stat.st_ino;
+				}
+			}
 		}
 
 		[ProtoMember(1)]
@@ -65,6 +73,8 @@ namespace VDF.Core {
 		public DateTime DateModified;
 		[ProtoMember(8)]
 		public long FileSize;
+		[ProtoMember(9)]
+		public ulong Inode;
 
 		[ProtoIgnore]
 		internal bool invalid = true;

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -477,6 +477,16 @@ namespace VDF.Core {
 								continue;
 						}
 
+						// Shortcut for linux, if the inodes are known and they are the same
+						// these two files are by definition hard links of each other
+						// no further inspection necessary
+						if (Settings.ExcludeHardLinks &&
+							entry.Inode > 0 &&
+							entry.Inode == compItem.Inode) {
+							isDuplicate = false;
+							break;
+						}
+
 
 						flags = DuplicateFlags.None;
 						isDuplicate = CheckIfDuplicate(entry, null, compItem, out difference);


### PR DESCRIPTION
This implements inode comparisons for accurate hard link detection in linux.

I'm not sure what affects the ProtoMember changes have by adding a new field to the FileEntry struct.