### PR TITLE
add instructions about signing the binary on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ You may need to set execute permission first `sudo chmod 777 VDF.GUI`
 Install ffmpeg / ffprobe using homebrew
 
 Open terminal in VDF folder and execute `./VDF.GUI` or if you have .NET installed `dotnet VDF.GUI.dll`
+
 You may get a permission error. Open system settings of your Mac, go to `Privacy & Security` and then `Developer Tools`. Now add `Terminal` to the list.
+
+If the process is immediately killed (something like `zsh: killed`), the binary likely needs to be signed. Run `codesign --force --sign - ./VDF.GUI` and try again.
 
 # Screenshots (slightly outdated)
 <img src="https://user-images.githubusercontent.com/46010672/129763067-8855a538-4a4f-4831-ac42-938eae9343bd.png" width="510">


### PR DESCRIPTION
I had trouble getting the program to run on macOS. Eventually figured out that macOS kills the process because its not signed. I added instructions to the readme for this.