### PR TITLE
make compare tolerant against slight variations in thumbnails

### DIFF
--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -421,19 +421,18 @@ namespace VDF.Core {
 				return difference <= differenceLimit;
 			}
 
-			float diff, diffSum = 0;
+			differenceLimit *= positionList.Count;
+			float diffSum = 0;
 			for (int j = 0; j < positionList.Count; j++) {
-				diff = ignoreBlackPixels || ignoreWhitePixels ?
+				diffSum += ignoreBlackPixels || ignoreWhitePixels ?
 							GrayBytesUtils.PercentageDifferenceWithoutSpecificPixels(
 								grayBytes[entry.GetGrayBytesIndex(positionList[j])]!,
 								compItem.grayBytes[compItem.GetGrayBytesIndex(positionList[j])]!, ignoreBlackPixels, ignoreWhitePixels) :
 							GrayBytesUtils.PercentageDifference(
 								grayBytes[entry.GetGrayBytesIndex(positionList[j])]!,
 								compItem.grayBytes[compItem.GetGrayBytesIndex(positionList[j])]!);
-				if (diff > differenceLimit)
+				if (diffSum > differenceLimit) // already exceeding maximum tolerated diff -> exit early
 					return false;
-				else
-					diffSum += diff;
 			}
 			difference = diffSum / positionList.Count;
 			return !float.IsNaN(difference);


### PR DESCRIPTION
When comparing individual thumbnails allow variations unless they exceed a value where it can no longer fit into the acceptable threshold.

fixes #560 