### PR TITLE
fix crash when resulting image exceeds dimension or memory limit

### DIFF
--- a/VDF.GUI/Utils/ImageUtils.cs
+++ b/VDF.GUI/Utils/ImageUtils.cs
@@ -39,6 +39,12 @@ namespace VDF.GUI.Utils {
 				tmpwidth += pImgList[i].Width;
 			}
 
+			// Check if the resulting image exceeds the maximum width
+			if (width > 65535 || width*height*4 > 128*1024*1024) {
+				// Resize to fit within the maximum width and max memory in ImageShart (128M)
+				img.Mutate(x => x.Resize((int)(width/((width * height * 4)/(128*1024*1024))), 0, KnownResamplers.Lanczos3));
+			}
+
 			using MemoryStream ms = new();
 			img.Save(ms, new SixLabors.ImageSharp.Formats.Jpeg.JpegEncoder());
 			ms.Position = 0;


### PR DESCRIPTION
Image library has a width limit on JPEG images. In addition it also has a memory limit. Simply resizing an image to a maximum width of 65535 does not work. As memory limit seems to be 128M, I calculate a new width in which the image size fits into this memory limit.

fixes #561 