### PR TITLE
Make sure to set the owner of input and message box windows.

### DIFF
--- a/VDF.GUI/Views/InputBoxView.xaml.cs
+++ b/VDF.GUI/Views/InputBoxView.xaml.cs
@@ -52,6 +52,7 @@ namespace VDF.GUI.Views {
 			((InputBoxVM)DataContext).HasYesButton = (buttons & MessageBoxButtons.Yes) != 0;
 
 			InitializeComponent();
+			Owner = ApplicationHelpers.MainWindow;
 
 			if (!VDF.GUI.Data.SettingsFile.Instance.DarkMode)
 				RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Light;

--- a/VDF.GUI/Views/MessageBoxView.xaml.cs
+++ b/VDF.GUI/Views/MessageBoxView.xaml.cs
@@ -57,6 +57,7 @@ namespace VDF.GUI.Views {
 
 			DataContext = vm;
 			InitializeComponent();
+			Owner = ApplicationHelpers.MainWindow;
 			if (!VDF.GUI.Data.SettingsFile.Instance.DarkMode)
 				RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Light;
 			//Opened += MessageBoxView_Opened;


### PR DESCRIPTION
This fixes issues seen in some environments (e.g. Linux with Openbox), where the state of the main window was changed when displaying an input or message box. The focus was also not set to the new displayed window.