### PR TITLE
Fix the command binding for the "Open File" context menu item

### DIFF
--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -646,13 +646,13 @@
                                         <TreeDataGrid.ContextMenu>
                                             <ContextMenu>
                                                 <MenuItem
-                                                    Command="{Binding OpenItemInFolderCommand}"
+                                                    Command="{Binding OpenItemCommand}"
                                                     Header="{Binding Source={x:Static local:App.Lang}, Path=[MainWindow.ContextMenu.OpenFile]}"
-                                                    InputGesture="Return" />
+                                                    InputGesture="Enter" />
                                                 <MenuItem
                                                     Command="{Binding OpenItemInFolderCommand}"
                                                     Header="{Binding Source={x:Static local:App.Lang}, Path=[MainWindow.ContextMenu.OpenInFolder]}"
-                                                    InputGesture="Shift+Return" />
+                                                    InputGesture="Shift+Enter" />
                                                 <MenuItem
                                                     Command="{Binding RenameFileCommand}"
                                                     Header="{Binding Source={x:Static local:App.Lang}, Path=[MainWindow.ContextMenu.RenameFile]}"


### PR DESCRIPTION
## Problem

The `Open File` context menu item behaves the same as `Open In Folder`.

Furthermore, there is an inconsistency between the input gesture displayed for the `Open File` and `Open In Folder` context menu items and their corresponding key bindings. The input gestures displayed are `Return` and `Shift+Return`, respectively, while the key bindings are `Enter` and `Shift+Enter`.

## Solution

Bind the OpenItemCommand to the "Open File" MenuItem and replace `Return` with `Enter` as the InputGesture.