### PR TITLE
Fix native ffmpeg library search path on Linux

### DIFF
--- a/VDF.Core/FFTools/FFToolsUtils.cs
+++ b/VDF.Core/FFTools/FFToolsUtils.cs
@@ -40,7 +40,6 @@ namespace VDF.Core.FFTools {
 		/// <param name="tool"></param>
 		/// <returns>path or null if not found</returns>
 		internal static string? GetPath(FFTool tool) {
-
 			if (File.Exists($"{CoreUtils.CurrentFolder}\\bin\\{(tool == FFTool.FFmpeg ? ffMpegPlatformName : ffProbePlatformName)}"))
 				return $"{CoreUtils.CurrentFolder}\\bin\\{(tool == FFTool.FFmpeg ? ffMpegPlatformName : ffProbePlatformName)}";
 			if (File.Exists(Path.Combine(CoreUtils.CurrentFolder, tool == FFTool.FFmpeg ? ffMpegPlatformName : ffProbePlatformName)))
@@ -59,8 +58,10 @@ namespace VDF.Core.FFTools {
 						MatchCasing = MatchCasing.CaseInsensitive
 					});
 
-					if (files.Length > 0)
+					if (files.Length > 0) {
+						Logger.Instance.Info($"Found {tool} binary: {files[0].FullName}");
 						return files[0].FullName;
+					}
 				}
 				catch (Exception) {
 #if DEBUG

--- a/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
+++ b/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
@@ -99,7 +99,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 						}
 					}
 				}
-				var environmentVariables = Environment.GetEnvironmentVariable("PATH")?.Split(Path.PathSeparator);
+				var environmentVariables = Environment.GetEnvironmentVariable("LD_LIBRARY_PATH")?.Split(Path.PathSeparator);
 				if (environmentVariables == null)
 					return false;
 


### PR DESCRIPTION
System installed ffmpeg library not working on Linux (at least not non-FHS distros like NixOS) because it wrongly used `PATH` instead of `LD_LIBRARY_PATH` to find the ffmpeg library. Especially problematic if VDF download is undesired or will fail (due to program dir being read-only or unpatched binaries being unable to run).