### PR TITLE
Fix native FFmpeg binding for 10-bit HEVC (VAAPI/CUDA/QSV)

### DIFF
--- a/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
+++ b/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
@@ -54,7 +54,14 @@ namespace VDF.Core.FFTools.FFmpegNative {
 
 			CodecName = ffmpeg.avcodec_get_name(codec->id);
 			FrameSize = new Size(_pCodecContext->width, _pCodecContext->height);
-			PixelFormat = HWDeviceType == AVHWDeviceType.AV_HWDEVICE_TYPE_NONE ? _pCodecContext->pix_fmt : GetHWPixelFormat(HWDeviceType, codec);
+			// For HW decode we intentionally defer the source pixel format until the
+			// first frame has been downloaded with av_hwframe_transfer_data — only then
+			// do we know the real sw_format (e.g. P010LE for 10-bit HEVC vs NV12 for
+			// 8-bit). Guessing before decode breaks 10-bit content.
+			PixelFormat = HWDeviceType == AVHWDeviceType.AV_HWDEVICE_TYPE_NONE
+				? _pCodecContext->pix_fmt
+				: AVPixelFormat.AV_PIX_FMT_NONE;
+			IsHardwareDecode = HWDeviceType != AVHWDeviceType.AV_HWDEVICE_TYPE_NONE;
 
 			_pPacket = ffmpeg.av_packet_alloc();
 			_pFrame = ffmpeg.av_frame_alloc();
@@ -63,6 +70,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		public string CodecName { get; }
 		public Size FrameSize { get; }
 		public AVPixelFormat PixelFormat { get; }
+		public bool IsHardwareDecode { get; }
 
 		protected virtual void Dispose(bool disposing) {
 			ReleaseUnmanaged();
@@ -152,38 +160,5 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			return true;
 		}
 
-		private unsafe AVPixelFormat GetHWPixelFormat(AVHWDeviceType hwDevice, AVCodec* codec) {
-			const int AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX = 1;
-			AVPixelFormat pixelFormat = AVPixelFormat.AV_PIX_FMT_NONE;
-
-			for (int i = 0; ; i++) {
-				AVCodecHWConfig* hwConfig = ffmpeg.avcodec_get_hw_config(codec, i);
-				if (hwConfig == null) {
-					throw new Exception($"Failed to find compatible pixel format for {hwDevice}");
-				}
-				if ((hwConfig->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) == 0 || hwConfig->device_type != hwDevice) {
-					continue;
-				}
-
-				AVHWFramesConstraints* hwConstraints = ffmpeg.av_hwdevice_get_hwframe_constraints(_pCodecContext->hw_device_ctx, hwConfig);
-				if (hwConstraints != null) {
-					for (AVPixelFormat* p = hwConstraints->valid_sw_formats; *p != AVPixelFormat.AV_PIX_FMT_NONE; p++) {
-						pixelFormat = *p;
-						if (ffmpeg.sws_isSupportedInput(pixelFormat) > 0) {
-							break;
-						}
-						else {
-							pixelFormat = AVPixelFormat.AV_PIX_FMT_NONE;
-						}
-					}
-
-					ffmpeg.av_hwframe_constraints_free(&hwConstraints);
-				}
-
-				if (pixelFormat != AVPixelFormat.AV_PIX_FMT_NONE) {
-					return pixelFormat;
-				}
-			}
-		}
 	}
 }

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -63,10 +63,21 @@ namespace VDF.Core.FFTools {
 					};
 
 					using var vsd = new VideoStreamDecoder(settings.File, HWDevice);
-					if (vsd.PixelFormat < 0 || vsd.PixelFormat >= AVPixelFormat.AV_PIX_FMT_NB)
-						throw new Exception($"Invalid source pixel format");
 
 					Size sourceSize = vsd.FrameSize;
+
+					// Decode first so we know the real source pixel format. For HW decode
+					// we can't know this up front — the downloaded sw_format depends on
+					// the stream's bit depth (NV12 for 8-bit, P010LE for 10-bit HEVC, etc.).
+					if (!vsd.TryDecodeFrame(out var srcFrame, settings.Position))
+						throw new Exception($"TryDecodeFrame failed at pos={settings.Position} for '{settings.File}'. size={sourceSize.Width}x{sourceSize.Height}");
+
+					AVPixelFormat srcPixFmt = vsd.IsHardwareDecode
+						? (AVPixelFormat)srcFrame.format
+						: vsd.PixelFormat;
+					if (srcPixFmt < 0 || srcPixFmt >= AVPixelFormat.AV_PIX_FMT_NB)
+						throw new Exception($"Invalid source pixel format {srcPixFmt}");
+
 					Size destinationSize = isGrayByte ? new Size(N, N) :
 						settings.Fullsize == 1 ?
 							sourceSize :
@@ -77,15 +88,13 @@ namespace VDF.Core.FFTools {
 						AVPixelFormat.AV_PIX_FMT_BGRA;
 
 					using var vfc = new VideoFrameConverter(
-										sourceSize: vsd.FrameSize,
-										sourcePixelFormat: vsd.PixelFormat,
+										sourceSize: sourceSize,
+										sourcePixelFormat: srcPixFmt,
 										destinationSize: destinationSize,
 										destinationPixelFormat: destinationPixelFrmt,
 										quality: VideoFrameConverter.ScaleQuality.Bicubic,
 										bitExact: false);
 
-					if (!vsd.TryDecodeFrame(out var srcFrame, settings.Position))
-						throw new Exception($"TryDecodeFrame failed at pos={settings.Position} for '{settings.File}'. srcPixFmt={vsd.PixelFormat} size={sourceSize.Width}x{sourceSize.Height}");
 					AVFrame convertedFrame = vfc.Convert(srcFrame);
 
 					if (convertedFrame.data[0] == null)


### PR DESCRIPTION
## Summary

The native FFmpeg binding throws `Failed to find compatible pixel format for AV_HWDEVICE_TYPE_VAAPI` on 10-bit HEVC content (4K HDR, etc.), even on GPUs that fully support HEVC Main 10 decode. Process-mode ffmpeg decodes the same files without issue. Two bugs in `GetHWPixelFormat` cause this:

1. `av_hwdevice_get_hwframe_constraints(ctx, hwConfig)` is passed an `AVCodecHWConfig*` as its second argument. FFmpeg's API expects a *device-specific* opaque struct there (or `NULL`). On VAAPI this returns null, the `valid_sw_formats` scan is skipped, and the outer loop eventually exhausts the codec's hw_configs and throws.
2. Even when constraints are valid, picking the **first** sws-supported entry in `valid_sw_formats` is a guess. The first entry is typically `NV12`, but for 10-bit HEVC `av_hwframe_transfer_data` downloads `P010LE` surfaces. The sws scaler would then misinterpret 10-bit planes as 8-bit.

The core design flaw is that the pre-decode guess can't know the source bit depth — the downloaded `sw_format` depends on what the decoder actually produces.

## Fix

Defer source-pixel-format discovery until after the first frame is decoded and transferred. `av_hwframe_transfer_data` populates `AVFrame->format` with the real sw_format (`P010LE` for 10-bit HEVC, `NV12` for 8-bit, etc.), so we read it from there and build the sws scaler accordingly.

- Drop the buggy `GetHWPixelFormat` helper.
- `VideoStreamDecoder.PixelFormat` now reflects the SW pix_fmt only for CPU decode; it is `AV_PIX_FMT_NONE` for HW paths.
- Add `IsHardwareDecode` so callers branch on the path.
- `FfmpegEngine.GetThumbnail`: decode, then construct `VideoFrameConverter` using the actual post-transfer frame format.

Same fix applies to CUDA/QSV/D3D11VA, which have the same bit-depth-dependent sw_format behavior.

## Test plan

- [x] Builds clean against `master` HEAD (`dotnet build VDF.Core/VDF.Core.csproj -c Release`)
- [x] `VDF.Core.Tests` pass (89/90 — the one failure, `FftServiceTests.Forward_PureSineWave_PeakAtExpectedBin`, reproduces on unmodified `master` and is unrelated)
- [x] Reproduced original failure on 4K HEVC Main 10 (`yuv420p10le`) with Intel VAAPI — native binding threw, process mode worked
- [x] With the patch applied, the same files would be handled by the native binding (logic traced; physical deployment pending upstream merge/package rebuild)

## Related

- Originates from #288 (CrendKing's `GetHWPixelFormat` introduction in 2022). The approach worked for 8-bit content common at the time but was fragile against bit-depth-dependent sw_formats.

## Notes

No API break from a user's perspective. `VideoStreamDecoder.PixelFormat` semantics change subtly for the HW path (was a guessed sw_format, is now `AV_PIX_FMT_NONE`), but the only in-tree consumer was `FfmpegEngine.GetThumbnail`, which is updated accordingly.