### PR TITLE
Fix native FFmpeg crashes by allocating padded swscale destination frames

### DIFF
--- a/VDF.Core/FFTools/FFmpegNative/VideoFrameConverter.cs
+++ b/VDF.Core/FFTools/FFmpegNative/VideoFrameConverter.cs
@@ -14,22 +14,18 @@
 // */
 //
 
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using FFmpeg.AutoGen;
 
 namespace VDF.Core.FFTools.FFmpegNative {
 	sealed unsafe class VideoFrameConverter : IDisposable {
-		private readonly IntPtr _convertedFrameBufferPtr;
 		private readonly Size _destinationSize;
-		private readonly byte_ptrArray4 _dstData;
-		private readonly int_array4 _dstLinesize;
+		private readonly AVFrame* _pConvertedFrame;
 		private readonly SwsContext* _pConvertContext;
 
 		public enum ScaleQuality {
 			FastBilinear,
 			Bilinear,
-			Bicubic,   // empfohlen
+			Bicubic,
 			Lanczos,
 			Spline,
 			Area
@@ -69,50 +65,37 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			if (_pConvertContext == null)
 				throw new FFInvalidExitCodeException("Could not initialize the conversion context.");
 
+			_pConvertedFrame = ffmpeg.av_frame_alloc();
+			if (_pConvertedFrame == null)
+				throw new FFInvalidExitCodeException("Failed to allocate destination AVFrame.");
 
-			int convertedFrameBufferSize = ffmpeg.av_image_get_buffer_size(destinationPixelFormat,
-				destinationSize.Width,
-				destinationSize.Height,
-				1).ThrowExceptionIfError();
-			_convertedFrameBufferPtr = Marshal.AllocHGlobal(convertedFrameBufferSize);
-			_dstData = new byte_ptrArray4();
-			_dstLinesize = new int_array4();
+			_pConvertedFrame->format = (int)destinationPixelFormat;
+			_pConvertedFrame->width = destinationSize.Width;
+			_pConvertedFrame->height = destinationSize.Height;
 
-			ffmpeg.av_image_fill_arrays(ref _dstData,
-				ref _dstLinesize,
-				(byte*)_convertedFrameBufferPtr,
-				destinationPixelFormat,
-				destinationSize.Width,
-				destinationSize.Height,
-				1).ThrowExceptionIfError();
+			// Give swscale a real padded destination frame instead of a tightly packed align=1 buffer.
+			// The WinDbg trace showed an invalid write inside swscale-9.dll while writing the converted
+			// destination image, so we intentionally request aligned/padded frame buffers here.
+			ffmpeg.av_frame_get_buffer(_pConvertedFrame, 64).ThrowExceptionIfError();
 		}
 
 		public void Dispose() {
-			Marshal.FreeHGlobal(_convertedFrameBufferPtr);
+			AVFrame* convertedFrame = _pConvertedFrame;
+			ffmpeg.av_frame_free(&convertedFrame);
 			ffmpeg.sws_freeContext(_pConvertContext);
 		}
 
 		public AVFrame Convert(AVFrame sourceFrame) {
+			ffmpeg.av_frame_make_writable(_pConvertedFrame).ThrowExceptionIfError();
 			ffmpeg.sws_scale(_pConvertContext,
 				sourceFrame.data,
 				sourceFrame.linesize,
 				0,
 				sourceFrame.height,
-				_dstData,
-				_dstLinesize).ThrowExceptionIfError();
+				_pConvertedFrame->data,
+				_pConvertedFrame->linesize).ThrowExceptionIfError();
 
-			byte_ptrArray8 data = new();
-			data.UpdateFrom(_dstData);
-			int_array8 linesize = new();
-			linesize.UpdateFrom(_dstLinesize);
-
-			return new AVFrame {
-				data = data,
-				linesize = linesize,
-				width = _destinationSize.Width,
-				height = _destinationSize.Height
-			};
+			return *_pConvertedFrame;
 		}
-
 	}
 }


### PR DESCRIPTION
## Summary

Fixes native FFmpeg crashes in the in-process thumbnail/scaling path by replacing the tightly packed destination buffer in `VideoFrameConverter` with a properly padded/aligned destination `AVFrame`.

## Root cause

The native path previously allocated the swscale destination image with:

- `av_image_get_buffer_size(..., align=1)`
- `av_image_fill_arrays(..., align=1)`

Under WinDbg + page heap, the crash was reproducible as an invalid write inside `swscale-9.dll` during scaling. The fault occurred in the destination write path, which strongly pointed to the destination buffer being too tightly packed for swscale's SIMD writes.

## Fix

`VideoFrameConverter` now:

- allocates a real destination `AVFrame`
- sets `format`, `width`, and `height`
- calls `av_frame_get_buffer(..., 64)` to get padded/aligned frame storage
- calls `av_frame_make_writable()` before each conversion
- passes that padded frame to `sws_scale`

## Validation

Before the fix:

- crash reproduced with native FFmpeg binding enabled
- WinDbg reported `INVALID_POINTER_WRITE_AVRF_c0000005_swscale-9.dll`

After the fix:

- full scan completed successfully
- duplicate results displayed successfully
- thumbnail retrieval completed successfully
- no crash