### PR TITLE
Fix crash in status bar text trimming

### DIFF
--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1165,7 +1165,7 @@
                                     </TextBlock>
                                     <Border Width="1" Margin="3,2" Background="{actipro:ThemeResource ButtonForegroundBrush}" />
                                     <TextBlock FontSize="12" Margin="2,0" Text="{Binding ScanProgressText, Mode=OneWay}"
-                                        TextTrimming="PrefixCharacterEllipsis" MaxWidth="500" />
+                                        TextTrimming="CharacterEllipsis" MaxWidth="500" />
                                 </StackPanel>
                             </WrapPanel>
                             <Grid


### PR DESCRIPTION
Switch TextTrimming from PrefixCharacterEllipsis to CharacterEllipsis to resolve a System.ArgumentOutOfRangeException in Avalonia's text layout engine. This occurs when the available width for prefix trimming becomes invalid or too small.

This works around a bug in PrefixCharacterEllipsis.

Fixes #723