### PR TITLE
Add Video Compare integration (group actions + custom launch arguments)

### DIFF
--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -56,6 +56,20 @@ namespace VDF.GUI.Data {
 			public string OpenMultiple { get; set; } = string.Empty;
 		}
 
+		string _VideoCompareExecutablePath = string.Empty;
+		[JsonPropertyName("VideoCompareExecutablePath")]
+		public string VideoCompareExecutablePath {
+			get => _VideoCompareExecutablePath;
+			set => this.RaiseAndSetIfChanged(ref _VideoCompareExecutablePath, value);
+		}
+
+		string _VideoCompareArguments = string.Empty;
+		[JsonPropertyName("VideoCompareArguments")]
+		public string VideoCompareArguments {
+			get => _VideoCompareArguments;
+			set => this.RaiseAndSetIfChanged(ref _VideoCompareArguments, value);
+		}
+
 		[JsonPropertyName("Includes")]
 		public ObservableCollection<string> Includes { get; set; } = new();
 		[JsonPropertyName("Blacklists")]

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -866,6 +866,118 @@ namespace VDF.GUI.ViewModels {
 			}
 		});
 
+		List<DuplicateItemVM>? ResolveVideoComparePair(Guid? groupId = null) {
+			var selected = GetSelectedDuplicates()
+				.Where(d => !d.ItemInfo.IsImage)
+				.ToList();
+			if (selected.Count == 2 && selected.Select(d => d.ItemInfo.GroupId).Distinct().Count() == 1)
+				return selected;
+
+			Guid resolvedGroupId;
+			if (groupId.HasValue)
+				resolvedGroupId = groupId.Value;
+			else {
+				if (GetSelectedDuplicateItem() is not DuplicateItemVM currentItem)
+					return null;
+				resolvedGroupId = currentItem.ItemInfo.GroupId;
+			}
+
+			var groupVideos = Duplicates
+				.Where(d => d.ItemInfo.GroupId == resolvedGroupId && !d.ItemInfo.IsImage)
+				.ToList();
+			return groupVideos.Count == 2 ? groupVideos : null;
+		}
+
+		string? ResolveVideoCompareExecutable() {
+			var path = SettingsFile.Instance.VideoCompareExecutablePath?.Trim();
+			if (string.IsNullOrWhiteSpace(path))
+				return null;
+			return path;
+		}
+		static IEnumerable<string> ParseVideoCompareArguments() {
+			var raw = SettingsFile.Instance.VideoCompareArguments;
+			if (string.IsNullOrWhiteSpace(raw))
+				return [];
+
+			var args = new List<string>();
+			var token = new StringBuilder();
+			bool inDoubleQuotes = false;
+			bool inSingleQuotes = false;
+
+			for (int i = 0; i < raw.Length; i++) {
+				var c = raw[i];
+				if (c == '\\' && i + 1 < raw.Length) {
+					if ((raw[i + 1] == '"' || raw[i + 1] == '\'')) {
+						token.Append(raw[i + 1]);
+						i++;
+						continue;
+					}
+				}
+
+				if (!inSingleQuotes && c == '"') {
+					inDoubleQuotes = !inDoubleQuotes;
+					continue;
+				}
+
+				if (!inDoubleQuotes && c == '\'') {
+					inSingleQuotes = !inSingleQuotes;
+					continue;
+				}
+
+				if (!inSingleQuotes && !inDoubleQuotes && char.IsWhiteSpace(c)) {
+					if (token.Length > 0) {
+						args.Add(token.ToString());
+						token.Clear();
+					}
+
+					continue;
+				}
+
+				token.Append(c);
+			}
+
+			if (token.Length > 0)
+				args.Add(token.ToString());
+
+			return args;
+		}
+
+		public async Task OpenGroupInVideoCompare(Guid? groupId = null) {
+			var pair = ResolveVideoComparePair(groupId);
+			if (pair == null) {
+				await MessageBoxService.Show("Video Compare requires exactly two video items from the same group. Select two videos, or use it on a group that contains exactly two videos.");
+				return;
+			}
+
+			var exePath = ResolveVideoCompareExecutable();
+			if (string.IsNullOrWhiteSpace(exePath)) {
+				await MessageBoxService.Show("Set the video-compare executable path in Settings before using Video Compare.");
+				return;
+			}
+			if ((exePath.Contains(Path.DirectorySeparatorChar) || exePath.Contains(Path.AltDirectorySeparatorChar)) && !File.Exists(exePath)) {
+				await MessageBoxService.Show($"video-compare was not found at '{exePath}'.");
+				return;
+			}
+
+			try {
+				var psi = new ProcessStartInfo {
+					FileName = exePath,
+					UseShellExecute = false,
+					CreateNoWindow = true,
+				};
+				psi.ArgumentList.Add(pair[0].ItemInfo.Path);
+				psi.ArgumentList.Add(pair[1].ItemInfo.Path);
+				foreach (var argument in ParseVideoCompareArguments())
+					psi.ArgumentList.Add(argument);
+				Process.Start(psi);
+			}
+			catch (Exception ex) {
+				await MessageBoxService.Show($"Failed to start video-compare: {ex.Message}");
+			}
+		}
+
+		public ReactiveCommand<Unit, Unit> OpenGroupInVideoCompareCommand => ReactiveCommand.CreateFromTask(() => OpenGroupInVideoCompare());
+
 		public async void OpenItems() {
 			if (AlternativeOpen(SettingsFile.Instance.CustomCommands.OpenItem,
 								SettingsFile.Instance.CustomCommands.OpenMultiple))

--- a/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
@@ -17,6 +17,7 @@
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Reactive;
 using System.Reflection;
@@ -115,6 +116,41 @@ namespace VDF.GUI.ViewModels {
 			catch {
 				await MessageBoxService.Show(App.Lang["Message.OpenHwAccelInfoFailed"]);
 			}
+		});
+		public ReactiveCommand<Unit, Unit> OpenVideoCompareProjectLinkCommand => ReactiveCommand.CreateFromTask(async () => {
+			try {
+				Process.Start(new ProcessStartInfo {
+					FileName = "https://github.com/pixop/video-compare",
+					UseShellExecute = true
+				});
+			}
+			catch {
+				await MessageBoxService.Show(App.Lang["Message.OpenHwAccelInfoFailed"]);
+			}
+		});
+		public ReactiveCommand<Unit, Unit> BrowseVideoCompareExecutableCommand => ReactiveCommand.CreateFromTask(async () => {
+			string? startFolder = null;
+			var currentPath = SettingsFile.Instance.VideoCompareExecutablePath;
+			if (!string.IsNullOrWhiteSpace(currentPath)) {
+				startFolder = Path.GetDirectoryName(currentPath);
+				if (string.IsNullOrWhiteSpace(startFolder) || !Directory.Exists(startFolder))
+					startFolder = null;
+			}
+
+			var result = await Utils.PickerDialogUtils.OpenFilePicker(new FilePickerOpenOptions {
+				Title = "Select video-compare executable",
+				SuggestedStartLocation = startFolder == null
+					? null
+					: await ApplicationHelpers.MainWindow.StorageProvider.TryGetFolderFromPathAsync(startFolder),
+				FileTypeFilter = OperatingSystem.IsWindows()
+					? [new FilePickerFileType("Executable") { Patterns = ["*.exe"] }]
+					: null
+			});
+
+			if (string.IsNullOrWhiteSpace(result))
+				return;
+
+			SettingsFile.Instance.VideoCompareExecutablePath = result;
 		});
 		public ReactiveCommand<Unit, Unit> AddIncludesToListCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Utils.PickerDialogUtils.OpenDialogPicker(

--- a/VDF.GUI/Views/MainWindow.xaml
+++ b/VDF.GUI/Views/MainWindow.xaml
@@ -1794,6 +1794,32 @@
                                                                    ToolTip.Tip="{Binding Source={x:Static local:App.Lang}, Path=[MainWindow.Settings.DatabaseCheckpointIntervalTooltip]}" />
                                                 </StackPanel>
                                             </Border>
+                                            <!-- Video Compare -->
+                                            <Border Background="{actipro:ThemeResource Container1BackgroundBrush}"
+                                                    BorderBrush="{actipro:ThemeResource Container1BorderBrush}"
+                                                    BorderThickness="1" CornerRadius="6" Padding="12">
+                                                <StackPanel Spacing="8">
+                                                    <TextBlock Text="Video Compare" FontSize="14" FontWeight="Bold" />
+                                                    <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,0,0,2">
+                                                        <TextBlock FontSize="14" Text="Video Compare Path" />
+                                                        <Button Classes="hyperlink"
+                                                                HorizontalAlignment="Left"
+                                                                Command="{Binding OpenVideoCompareProjectLinkCommand}"
+                                                                Content="video-compare project" />
+                                                    </StackPanel>
+                                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                                        <TextBox Width="250" HorizontalAlignment="Left"
+                                                                 Text="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=VideoCompareExecutablePath}"
+                                                                 ToolTip.Tip="Path to the video-compare binary. When set, group headers show a Video Compare button." />
+                                                        <Button Content="Browse..."
+                                                                Command="{Binding BrowseVideoCompareExecutableCommand}" />
+                                                    </StackPanel>
+                                                    <TextBlock FontSize="14" Text="Custom video-compare Arguments:" />
+                                                    <TextBox Width="500" HorizontalAlignment="Left"
+                                                             Text="{Binding Source={x:Static Settings:SettingsFile.Instance}, Path=VideoCompareArguments}"
+                                                             ToolTip.Tip="Arguments passed to video-compare after the two selected files." />
+                                                </StackPanel>
+                                            </Border>
                                         </StackPanel>
                                     </ScrollViewer>
                                 </TabItem>

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -21,10 +21,12 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
+using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Markup.Xaml;
 using Avalonia.Markup.Xaml.Styling;
 using Avalonia.Media;
+using Avalonia.Controls.Primitives;
 using Avalonia.Platform.Storage;
 using Avalonia.Styling;
 using Avalonia.Themes.Fluent;
@@ -38,6 +40,9 @@ namespace VDF.GUI.Views {
 	public class MainWindow : Window {
 		bool keepBackupFile;
 		bool hasExited;
+		Point? pendingDuplicateDragStart;
+		DuplicateItemVM? pendingDuplicateDragItem;
+		bool duplicateDragInProgress;
 
 		public readonly Core.FFTools.FFHardwareAccelerationMode InitialHwMode;
 		public MainWindow() {
@@ -57,6 +62,10 @@ namespace VDF.GUI.Views {
 			this.FindControl<ListBox>("ListboxIncludelist")!.AddHandler(DragDrop.DragOverEvent, DragOver);
 			this.FindControl<ListBox>("ListboxBlacklist")!.AddHandler(DragDrop.DropEvent, DropBlacklist);
 			this.FindControl<ListBox>("ListboxBlacklist")!.AddHandler(DragDrop.DragOverEvent, DragOver);
+			var duplicatesGrid = this.FindControl<DataGrid>("dataGridGrouping")!;
+			duplicatesGrid.AddHandler(InputElement.PointerPressedEvent, OnDuplicatesGridPointerPressed, RoutingStrategies.Tunnel);
+			duplicatesGrid.AddHandler(InputElement.PointerMovedEvent, OnDuplicatesGridPointerMoved, RoutingStrategies.Tunnel);
+			duplicatesGrid.AddHandler(InputElement.PointerReleasedEvent, OnDuplicatesGridPointerReleased, RoutingStrategies.Tunnel);
 
 			ApplicationHelpers.CurrentApplicationLifetime.Startup += MainWindow_Startup;
 			ApplicationHelpers.CurrentApplicationLifetime.Exit += MainWindow_Exit;
@@ -176,6 +185,93 @@ namespace VDF.GUI.Views {
 			// Only allow if the dragged data contains filenames.
 			if (!e.DataTransfer.Contains(DataFormat.File))
 				e.DragEffects = DragDropEffects.None;
+		}
+
+		void OnDuplicatesGridPointerPressed(object? sender, PointerPressedEventArgs e) {
+			if (IsDuplicateDragBlockedByControl(e.Source as Visual))
+				return;
+
+			if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) {
+				ClearPendingDuplicateDrag();
+				return;
+			}
+
+			var source = e.Source as Visual;
+			pendingDuplicateDragItem = source?
+				.GetVisualAncestors()
+				.OfType<Control>()
+				.Select(c => c.DataContext)
+				.OfType<DuplicateItemVM>()
+				.FirstOrDefault()
+				?? (source as Control)?.DataContext as DuplicateItemVM;
+			pendingDuplicateDragStart = pendingDuplicateDragItem == null ? null : e.GetPosition(this);
+		}
+
+		bool IsDuplicateDragBlockedByControl(Visual? visual) {
+			if (visual == null)
+				return false;
+
+			return visual.GetVisualAncestors()
+				.Concat(new[] { visual })
+				.OfType<Control>()
+				.Any(c => c is ScrollViewer || c is ScrollBar);
+		}
+
+		async void OnDuplicatesGridPointerMoved(object? sender, PointerEventArgs e) {
+			if (duplicateDragInProgress || pendingDuplicateDragStart == null || pendingDuplicateDragItem == null)
+				return;
+			if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) {
+				ClearPendingDuplicateDrag();
+				return;
+			}
+
+			var current = e.GetPosition(this);
+			var delta = current - pendingDuplicateDragStart.Value;
+			const double dragThreshold = 6d;
+			if (Math.Abs(delta.X) < dragThreshold && Math.Abs(delta.Y) < dragThreshold)
+				return;
+
+			var grid = this.FindControl<DataGrid>("dataGridGrouping")!;
+			var selected = grid.SelectedItems?.Cast<DuplicateItemVM>().ToList() ?? new List<DuplicateItemVM>();
+			var itemsToDrag = selected.Any(i => ReferenceEquals(i, pendingDuplicateDragItem))
+				? selected
+				: new List<DuplicateItemVM> { pendingDuplicateDragItem };
+			var files = await BuildDuplicateFileDragItemsAsync(itemsToDrag);
+			if (files.Count == 0) {
+				ClearPendingDuplicateDrag();
+				return;
+			}
+
+			var data = new DataTransfer();
+			foreach (var file in files)
+				data.Add(DataTransferItem.CreateFile(file));
+			duplicateDragInProgress = true;
+			try {
+				await DragDrop.DoDragDropAsync(e, data, DragDropEffects.Copy);
+			}
+			finally {
+				duplicateDragInProgress = false;
+				ClearPendingDuplicateDrag();
+			}
+		}
+
+		void OnDuplicatesGridPointerReleased(object? sender, PointerReleasedEventArgs e) => ClearPendingDuplicateDrag();
+
+		void ClearPendingDuplicateDrag() {
+			pendingDuplicateDragStart = null;
+			pendingDuplicateDragItem = null;
+		}
+
+		async Task<List<IStorageItem>> BuildDuplicateFileDragItemsAsync(IEnumerable<DuplicateItemVM> items) {
+			var files = new List<IStorageItem>();
+			foreach (var path in items.Select(i => i.ItemInfo.Path).Distinct(PathComparer.ForCurrentPlatform)) {
+				if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+					continue;
+				var file = await StorageProvider.TryGetFileFromPathAsync(path);
+				if (file != null)
+					files.Add(file);
+			}
+			return files;
 		}
 
 		private void DropInclude(object? sender, DragEventArgs e) {

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -327,15 +327,28 @@ namespace VDF.GUI.Views {
 			}
 
 			var compareBtn = new Button { Content = "Compare", Classes = { "group-action" } };
+			var videoCompareBtn = new Button { Content = "Video Compare", Classes = { "group-action" } };
 			var keepBestBtn = new Button { Content = "Keep Best", Classes = { "group-action" } };
+			void UpdateVideoCompareVisibility() =>
+				videoCompareBtn.IsVisible = !string.IsNullOrWhiteSpace(SettingsFile.Instance.VideoCompareExecutablePath);
 
 			compareBtn.Click += (_, _) => {
 				var id = GetGroupId();
 				if (id != Guid.Empty) vm.CompareGroup(id);
 			};
+			videoCompareBtn.Click += async (_, _) => {
+				var id = GetGroupId();
+				if (id != Guid.Empty)
+					await vm.OpenGroupInVideoCompare(id);
+			};
 			keepBestBtn.Click += (_, _) => {
 				var id = GetGroupId();
 				if (id != Guid.Empty) vm.KeepBestInGroup(id);
+			};
+			UpdateVideoCompareVisibility();
+			SettingsFile.Instance.PropertyChanged += (_, args) => {
+				if (args.PropertyName == nameof(SettingsFile.VideoCompareExecutablePath))
+					UpdateVideoCompareVisibility();
 			};
 
 			var panel = new StackPanel {
@@ -343,7 +356,7 @@ namespace VDF.GUI.Views {
 				Spacing = 4,
 				Margin = new Thickness(8, 0, 4, 0),
 				VerticalAlignment = VerticalAlignment.Center,
-				Children = { compareBtn, keepBestBtn }
+				Children = { compareBtn, videoCompareBtn, keepBestBtn }
 			};
 
 			// Inject buttons into the header's visual tree once it's loaded


### PR DESCRIPTION
## Summary

- Allow dragging one or multiple videos from the duplicate grid to external programs
- Added **Video Compare** button in each duplicate group header action row
- Added **Video Compare** settings section (executable path, custom arguments, link to the [video-compare project](https://github.com/pixop/video-compare))
- Custom arguments support shell-style quoting (single/double quotes, escaped quotes)