### PR TITLE
feat(cli): add 'db export' command for headless database JSON export

### DIFF
--- a/VDF.CLI.Tests/Commands/DatabaseCommandTests.cs
+++ b/VDF.CLI.Tests/Commands/DatabaseCommandTests.cs
@@ -33,7 +33,7 @@ public class DatabaseCommandTests {
 		var cmd = DatabaseCommand.Build();
 		var root = new RootCommand { cmd };
 		var result = root.Parse("db export -o /tmp/test.json");
-		Assert.Equal(0, result.Errors.Count);
+		Assert.Empty(result.Errors);
 	}
 
 	[Fact]
@@ -41,6 +41,6 @@ public class DatabaseCommandTests {
 		var cmd = DatabaseCommand.Build();
 		var root = new RootCommand { cmd };
 		var result = root.Parse("db export -o /tmp/test.json --pretty");
-		Assert.Equal(0, result.Errors.Count);
+		Assert.Empty(result.Errors);
 	}
 }

--- a/VDF.CLI.Tests/Commands/DatabaseCommandTests.cs
+++ b/VDF.CLI.Tests/Commands/DatabaseCommandTests.cs
@@ -1,0 +1,46 @@
+// /*
+//     Copyright (C) 2026 0x90d
+//     This file is part of VideoDuplicateFinder
+//     VideoDuplicateFinder is free software: you can redistribute it and/or modify
+//     it under the terms of the GNU Affero General Public License as published by
+//     the Free Software Foundation, either version 3 of the License, or
+//     (at your option) any later version.
+//     VideoDuplicateFinder is distributed in the hope that it will be useful,
+//     but WITHOUT ANY WARRANTY without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//     GNU Affero General Public License for more details.
+//     You should have received a copy of the GNU Affero General Public License
+//     along with VideoDuplicateFinder.  If not, see <http://www.gnu.org/licenses/>.
+// */
+
+using System.CommandLine;
+using VDF.CLI.Commands;
+
+namespace VDF.CLI.Tests.Commands;
+
+public class DatabaseCommandTests {
+	[Fact]
+	public void DbCommand_Registers_Export_Subcommand() {
+		var cmd = DatabaseCommand.Build();
+		var export = cmd.Subcommands.FirstOrDefault(c => c.Name == "export");
+		Assert.NotNull(export);
+		Assert.Equal("Export the scan database to a JSON file (includes fingerprints, media info, and perceptual hashes).",
+			export.Description);
+	}
+
+	[Fact]
+	public void DbExport_Parses_Output_Option() {
+		var cmd = DatabaseCommand.Build();
+		var root = new RootCommand { cmd };
+		var result = root.Parse("db export -o /tmp/test.json");
+		Assert.Equal(0, result.Errors.Count);
+	}
+
+	[Fact]
+	public void DbExport_Parses_Pretty_Flag() {
+		var cmd = DatabaseCommand.Build();
+		var root = new RootCommand { cmd };
+		var result = root.Parse("db export -o /tmp/test.json --pretty");
+		Assert.Equal(0, result.Errors.Count);
+	}
+}

--- a/VDF.CLI/Commands/DatabaseCommand.cs
+++ b/VDF.CLI/Commands/DatabaseCommand.cs
@@ -24,6 +24,7 @@ namespace VDF.CLI.Commands {
 			var cmd = new Command("db", "Database maintenance commands.");
 			cmd.Subcommands.Add(BuildClean());
 			cmd.Subcommands.Add(BuildClear());
+			cmd.Subcommands.Add(BuildExport());
 			return cmd;
 		}
 
@@ -83,6 +84,59 @@ namespace VDF.CLI.Commands {
 
 				ScanEngine.ClearDatabase();
 				Console.Error.WriteLine($"Database cleared. {count:N0} entries removed.");
+			});
+
+			return cmd;
+		}
+
+		static Command BuildExport() {
+			var cmd = new Command("export",
+				"Export the scan database to a JSON file (includes fingerprints, media info, and perceptual hashes).");
+
+			var outputOpt = new Option<FileInfo?>("--output", "-o") {
+				Description = "Path for the exported JSON file."
+			};
+			cmd.Options.Add(outputOpt);
+
+			var prettyOpt = new Option<bool>("--pretty") {
+				Description = "Write indented (pretty-printed) JSON."
+			};
+			cmd.Options.Add(prettyOpt);
+
+			cmd.Options.Add(SharedOptions.Database);
+
+			cmd.SetAction(async (parseResult, ct) => {
+				var db = parseResult.GetValue(SharedOptions.Database);
+				if (db != null) DatabaseUtils.CustomDatabaseFolder = db;
+
+				await ScanEngine.LoadDatabase();
+				int count = DatabaseUtils.Database.Count;
+				Console.Error.WriteLine($"Database loaded: {count:N0} entries.");
+
+				if (count == 0) {
+					Console.Error.WriteLine("Database is empty. Nothing to export.");
+					return;
+				}
+
+				var outputPath = parseResult.GetValue(outputOpt);
+				if (outputPath == null) {
+					Console.Error.WriteLine("Error: --output <path> is required.");
+					return;
+				}
+				bool pretty = parseResult.GetValue(prettyOpt);
+
+				var options = new System.Text.Json.JsonSerializerOptions {
+					IncludeFields = true,
+					WriteIndented = pretty,
+				};
+
+				bool ok = ScanEngine.ExportDataBaseToJson(outputPath.FullName, options);
+				if (ok) {
+					var fi = new System.IO.FileInfo(outputPath.FullName);
+					Console.Error.WriteLine($"Exported {count:N0} entries to {outputPath.FullName} ({fi.Length / 1_048_576.0:F1} MB).");
+				} else {
+					Console.Error.WriteLine("Export failed.");
+				}
 			});
 
 			return cmd;

--- a/VDF.CLI/Commands/DatabaseCommand.cs
+++ b/VDF.CLI/Commands/DatabaseCommand.cs
@@ -116,7 +116,7 @@ namespace VDF.CLI.Commands {
 
 				if (count == 0) {
 					Console.Error.WriteLine("Database is empty. Nothing to export.");
-					return;
+					return 1;
 				}
 
 				var outputPath = parseResult.GetValue(outputOpt)!;
@@ -131,8 +131,10 @@ namespace VDF.CLI.Commands {
 				if (ok) {
 					var fi = new System.IO.FileInfo(outputPath.FullName);
 					Console.Error.WriteLine($"Exported {count:N0} entries to {outputPath.FullName} ({fi.Length / 1_048_576.0:F1} MB).");
+					return 0;
 				} else {
 					Console.Error.WriteLine("Export failed.");
+					return 1;
 				}
 			});
 

--- a/VDF.CLI/Commands/DatabaseCommand.cs
+++ b/VDF.CLI/Commands/DatabaseCommand.cs
@@ -93,8 +93,9 @@ namespace VDF.CLI.Commands {
 			var cmd = new Command("export",
 				"Export the scan database to a JSON file (includes fingerprints, media info, and perceptual hashes).");
 
-			var outputOpt = new Option<FileInfo?>("--output", "-o") {
-				Description = "Path for the exported JSON file."
+			var outputOpt = new Option<FileInfo>("--output", "-o") {
+				Description = "Path for the exported JSON file.",
+				Required = true,
 			};
 			cmd.Options.Add(outputOpt);
 
@@ -118,11 +119,7 @@ namespace VDF.CLI.Commands {
 					return;
 				}
 
-				var outputPath = parseResult.GetValue(outputOpt);
-				if (outputPath == null) {
-					Console.Error.WriteLine("Error: --output <path> is required.");
-					return;
-				}
+				var outputPath = parseResult.GetValue(outputOpt)!;
 				bool pretty = parseResult.GetValue(prettyOpt);
 
 				var options = new System.Text.Json.JsonSerializerOptions {


### PR DESCRIPTION
Adds `vdf-cli db export --output path.json` for headless database JSON export. Uses the existing `ScanEngine.ExportDataBaseToJson()` public API. Useful for scripting/automation pipelines that need the full database dump (fingerprints, media info, pHashes) without the GUI.