### PR TITLE
Web/Docker: fix broken Web UI on .NET 10 (missing Blazor framework script)

### DIFF
--- a/VDF.Web/Dockerfile
+++ b/VDF.Web/Dockerfile
@@ -6,7 +6,7 @@ COPY ["VDF.Web/VDF.Web.csproj", "VDF.Web/"]
 RUN dotnet restore "VDF.Web/VDF.Web.csproj"
 COPY VDF.Core/ VDF.Core/
 COPY VDF.Web/ VDF.Web/
-RUN dotnet publish "VDF.Web/VDF.Web.csproj" -c Release -o /app/publish --no-restore
+RUN dotnet publish "VDF.Web/VDF.Web.csproj" -c Release -o /app/publish
 
 # Runtime stage
 FROM mcr.microsoft.com/dotnet/aspnet:10.0


### PR DESCRIPTION
## Problem

The Docker Web UI image (`ghcr.io/0x90d/vdf-web`) is currently broken: the page loads but **every interactive control, including the login button, is disabled**. The browser console shows:

```
GET /_framework/blazor.server.js  404 (Not Found)
```

`app.css` and `app.js` load fine, login (a plain form POST) works, but `_framework/blazor.server.js` 404s, so the SignalR circuit never starts and Blazor never makes the page interactive.

## Root cause

This regressed in `e89af26` ("Move to .NET 10"), but the actual bug is in `VDF.Web/Dockerfile`, not in any .NET runtime.

The Dockerfile uses the standard layer-cache pattern: copy only the `.csproj` files, `dotnet restore`, then copy the source and `dotnet publish --no-restore`.

In .NET 8/9 the Blazor framework script shipped inside the shared framework, so a csproj-only restore was sufficient. In **.NET 10 the script moved into the `microsoft.aspnetcore.app.internal.assets` NuGet package**, and the SDK only adds that package to the restore graph once the Razor component sources are present.

Because `dotnet restore` runs with *only* the `.csproj` (no `.razor` files yet), `project.assets.json` omits that package (`grep -c internal.assets project.assets.json` → `0`). The subsequent `--no-restore` publish then builds without it, so `_framework/blazor.server.js` is never emitted into the image.

## Fix

Drop `--no-restore` from the publish step so publish restores again with the full source present and pulls the framework assets in. The csproj-only restore layer still warms the NuGet cache, so the second restore is cheap, and Docker layer caching is unaffected.

## Verification

Built the image locally before and after:

| Check | Before | After |
| --- | --- | --- |
| `/app/wwwroot/_framework/blazor.server.js` published | absent | present |
| `GET /_framework/blazor.server.js` | 404 | 200 |
| `GET /_framework/blazor.web.js` | 404 | 200 |
| `POST /_blazor/negotiate` | n/a | 200 (circuit establishes) |

With the fix the framework script is served, the SignalR circuit negotiates, and the Web UI becomes interactive again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)