### PR TITLE
Refactor progress reporting in ScanEngine

### DIFF
--- a/VDF.Core.Tests/AiPartialPhaseVisibilityTests.cs
+++ b/VDF.Core.Tests/AiPartialPhaseVisibilityTests.cs
@@ -59,7 +59,7 @@ public class AiPartialPhaseVisibilityTests : IDisposable {
 		var events = new ConcurrentQueue<ScanProgressChangedEventArgs>();
 
 		// Stand in for the visual gate that ran just before: it ends full over its own maximum.
-		engine.InitProgress(12);
+		engine.InitProgress(12, "");
 		for (int i = 0; i < 12; i++)
 			engine.IncrementProgress("clip.mp4");
 		engine.Progress += (_, e) => events.Enqueue(e);

--- a/VDF.Core.Tests/PartialClipProgressTests.cs
+++ b/VDF.Core.Tests/PartialClipProgressTests.cs
@@ -58,7 +58,7 @@ public class PartialClipProgressTests {
 		engine.Progress += (_, e) => events.Enqueue(e);
 
 		// Stand in for the earlier audio pass: it ends with a full bar over its own maximum.
-		engine.InitProgress(6722);
+		engine.InitProgress(6722, "");
 		for (int i = 0; i < 6722; i++)
 			engine.IncrementProgress("audio.mp4");
 		Assert.Equal(6722, events.Last().CurrentPosition);
@@ -148,7 +148,7 @@ public class PartialClipProgressTests {
 		engine.ElapsedTimer.Start();
 
 		var events = new ConcurrentQueue<ScanProgressChangedEventArgs>();
-		engine.InitProgress(10);
+		engine.InitProgress(10, "");
 		engine.IncrementProgress("stalled.mp4");
 		engine.Progress += (_, e) => events.Enqueue(e);
 
@@ -173,7 +173,7 @@ public class PartialClipProgressTests {
 	public async Task Heartbeat_SurvivesAThrowingProgressSubscriber() {
 		var engine = new ScanEngine();
 		engine.ElapsedTimer.Start();
-		engine.InitProgress(10);
+		engine.InitProgress(10, "");
 		engine.IncrementProgress("stalled.mp4");
 		engine.Progress += (_, _) => throw new InvalidOperationException("a frontend blew up");
 
@@ -188,7 +188,7 @@ public class PartialClipProgressTests {
 	public async Task Heartbeat_IsSilentWhileTheClockIsStopped() {
 		var engine = new ScanEngine();
 		engine.ElapsedTimer.Start();
-		engine.InitProgress(10);
+		engine.InitProgress(10, "");
 		engine.IncrementProgress("paused.mp4");
 
 		var events = new ConcurrentQueue<ScanProgressChangedEventArgs>();
@@ -211,7 +211,7 @@ public class PartialClipProgressTests {
 		var events = new ConcurrentQueue<ScanProgressChangedEventArgs>();
 		engine.Progress += (_, e) => events.Enqueue(e);
 
-		engine.InitProgress(42);
+		engine.InitProgress(42, "");
 
 		var opening = Assert.Single(events);
 		Assert.Equal(0, opening.CurrentPosition);

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -138,15 +138,8 @@ namespace VDF.Core {
 			// (the visual gate decodes frames off disk) would otherwise leave the previous phase's
 			// finished-looking numbers on screen, and leave the heartbeat with nothing to refresh.
 			currentStageLabel = stage;
-			PushProgress(new ScanProgressChangedEventArgs {
-				CurrentPosition = 0,
-				CurrentFile = string.Empty,
-				Elapsed = ElapsedTimer.Elapsed,
-				Remaining = TimeSpan.Zero,
-				MaxPosition = scanProgressMaxValue,
-				CurrentStage = stage,
-			});
-			// After the push, so the phase's first completed item reports without waiting out the throttle.
+			ReportProgress("", stage, remaining: TimeSpan.Zero, ignoreInterval: true);
+			// Reset after the push, so the phase's first completed item reports without waiting out the throttle.
 			lastProgressUpdate = DateTime.MinValue;
 		}
 		void ResetExcludedLogging() {
@@ -214,16 +207,6 @@ namespace VDF.Core {
 				Logger.Instance.Warn(T("Log.ExcludedFilesSummaryItem", reason.Key, reason.Value, suppressionText));
 			}
 		}
-		/// <summary>
-		/// Raises <see cref="Progress"/> and keeps the snapshot the heartbeat re-sends.
-		/// </summary>
-		void PushProgress(ScanProgressChangedEventArgs args) {
-			lock (progressSnapshotLock) {
-				lastProgressSnapshot = args;
-				hasProgressSnapshot = true;
-			}
-			Progress?.Invoke(this, args);
-		}
 
 		/// <summary>
 		/// Linear extrapolation of the current phase's remaining time from what it has spent so far.
@@ -276,43 +259,44 @@ namespace VDF.Core {
 			Progress?.Invoke(this, snapshot);
 		}
 
-		internal void IncrementProgress(string path) {
-			// Atomic: workers of all concurrent drive groups increment this counter, and a
-			// torn increment would lose the processedFiles == scanProgressMaxValue final push.
-			int processed = Interlocked.Increment(ref processedFiles);
-			var pushUpdate = processed == scanProgressMaxValue ||
-								lastProgressUpdate + progressUpdateIntervall < DateTime.UtcNow;
-			if (!pushUpdate) return;
-			lastProgressUpdate = DateTime.UtcNow;
-			PushProgress(new ScanProgressChangedEventArgs {
-				CurrentPosition = processed,
-				CurrentFile = path,
-				Elapsed = ElapsedTimer.Elapsed,
-				Remaining = EstimateRemaining(processed, scanProgressMaxValue),
-				MaxPosition = scanProgressMaxValue,
-				CurrentStage = currentStageLabel,
-				Drives = driveProgressTracker?.Snapshot(),
-			});
-			TryDatabaseCheckpoint();
-		}
-
-		// Reports what's happening to a file mid-processing without advancing the file counter.
-		// Throttled to the same cadence as IncrementProgress so a stuck file's last-reported
+		// Used by IncrementProgress and to report what's happening to a file
+		// mid-processing without advancing the file counter.
+		// Throttled to the same cadence for both so a stuck file's last-reported
 		// stage (e.g. "sampling frame 2/5") hints at where it froze.
-		void ReportStage(string path, string stage, int stageCurrent = 0, int stageMax = 0) {
-			if (lastProgressUpdate + progressUpdateIntervall > DateTime.UtcNow) return;
+		private void ReportProgress(string path, string stage, int stageCurrent = 0, int stageMax = 0, TimeSpan? remaining = null, bool ignoreInterval = false) {
+			if (!ignoreInterval && lastProgressUpdate + progressUpdateIntervall > DateTime.UtcNow) {
+				return;
+			}
+			
 			lastProgressUpdate = DateTime.UtcNow;
-			PushProgress(new ScanProgressChangedEventArgs {
+
+			var args = new ScanProgressChangedEventArgs {
 				CurrentPosition = processedFiles,
 				CurrentFile = path,
 				Elapsed = ElapsedTimer.Elapsed,
-				Remaining = EstimateRemaining(processedFiles, scanProgressMaxValue),
+				Remaining = remaining ?? EstimateRemaining(processedFiles, scanProgressMaxValue),
 				MaxPosition = scanProgressMaxValue,
 				CurrentStage = stage,
 				StageCurrent = stageCurrent,
 				StageMax = stageMax,
 				Drives = driveProgressTracker?.Snapshot(),
-			});
+			};
+			
+			lock (progressSnapshotLock) {
+				lastProgressSnapshot = args;
+				hasProgressSnapshot = true;
+			}
+			Progress?.Invoke(this, args);
+			
+			TryDatabaseCheckpoint();
+		}
+
+		internal void IncrementProgress(string path) {
+			// Atomic: workers of all concurrent drive groups increment this counter, and a
+			// torn increment would lose the processedFiles == scanProgressMaxValue final push.
+			int processed = Interlocked.Increment(ref processedFiles);
+			var ignoreInterval = processed == scanProgressMaxValue;
+			ReportProgress(path, currentStageLabel, ignoreInterval: ignoreInterval);
 		}
 
 		void TryDatabaseCheckpoint() {
@@ -1109,11 +1093,11 @@ namespace VDF.Core {
 								if (NeedsAudioFingerprint(entry, Settings.EnablePartialClipDetection, Settings.AlwaysRetryFailedSampling)) {
 									string cachedAudioPath = entry.Path;
 									string audioStageLabel = T("Scan.Stage.AudioFingerprint");
-									ReportStage(cachedAudioPath, audioStageLabel);
+									ReportProgress(cachedAudioPath, audioStageLabel);
 									ScanCrashJournal.Begin(ScanCrashJournal.PhaseAudio, cachedAudioPath);
 									try {
 										ExtractAudioFingerprint(entry, cancelationTokenSource.Token,
-											onProgress: p => ReportStage(cachedAudioPath, audioStageLabel, (int)(p * 100), 100));
+											onProgress: p => ReportProgress(cachedAudioPath, audioStageLabel, (int)(p * 100), 100));
 									}
 									finally {
 										ScanCrashJournal.End();
@@ -1136,7 +1120,7 @@ namespace VDF.Core {
 						}
 
 						if (entry.mediaInfo == null && !entry.IsImage) {
-							ReportStage(entry.Path, T("Scan.Stage.Probing"));
+							ReportProgress(entry.Path, T("Scan.Stage.Probing"));
 							MediaInfo? info = FFProbeEngine.GetMediaInfo(entry.Path, Settings.ExtendedFFToolsLogging);
 							if (info == null) {
 								entry.invalid = true;
@@ -1177,7 +1161,7 @@ namespace VDF.Core {
 							try {
 								if (!FfmpegEngine.GetGrayBytesFromVideo(entry, positionList, Settings.MaxSamplingDurationSeconds,
 										Settings.ExtendedFFToolsLogging,
-										onSampleComplete: (done) => ReportStage(entryPath, samplingLabel, done, totalSamples),
+										onSampleComplete: (done) => ReportProgress(entryPath, samplingLabel, done, totalSamples),
 										embeddingSink: aiEmbeddingPipeline))
 									entry.invalid = true;
 							}
@@ -1191,11 +1175,11 @@ namespace VDF.Core {
 						if (NeedsAudioFingerprint(entry, Settings.EnablePartialClipDetection, Settings.AlwaysRetryFailedSampling)) {
 							string audioPath = entry.Path;
 							string audioLabel = T("Scan.Stage.AudioFingerprint");
-							ReportStage(audioPath, audioLabel);
+							ReportProgress(audioPath, audioLabel);
 							ScanCrashJournal.Begin(ScanCrashJournal.PhaseAudio, audioPath);
 							try {
 								ExtractAudioFingerprint(entry, cancelationTokenSource.Token,
-									onProgress: p => ReportStage(audioPath, audioLabel, (int)(p * 100), 100));
+									onProgress: p => ReportProgress(audioPath, audioLabel, (int)(p * 100), 100));
 							}
 							finally {
 								ScanCrashJournal.End();

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -128,7 +128,7 @@ namespace VDF.Core {
 		string T(string key, params object[] args) =>
 			LanguageService.Instance.Get(Settings.LanguageCode, key, args);
 
-		internal void InitProgress(int count) {
+		internal void InitProgress(int count, string stage) {
 			startTime = DateTime.UtcNow;
 			scanProgressMaxValue = count;
 			processedFiles = 0;
@@ -137,14 +137,14 @@ namespace VDF.Core {
 			// Publish the new phase's zeroed counters at once. A phase whose first item takes minutes
 			// (the visual gate decodes frames off disk) would otherwise leave the previous phase's
 			// finished-looking numbers on screen, and leave the heartbeat with nothing to refresh.
-			// Callers set currentStageLabel before calling, so the label switches with the counters.
+			currentStageLabel = stage;
 			PushProgress(new ScanProgressChangedEventArgs {
 				CurrentPosition = 0,
 				CurrentFile = string.Empty,
 				Elapsed = ElapsedTimer.Elapsed,
 				Remaining = TimeSpan.Zero,
 				MaxPosition = scanProgressMaxValue,
-				CurrentStage = currentStageLabel,
+				CurrentStage = stage,
 			});
 			// After the push, so the phase's first completed item reports without waiting out the throttle.
 			lastProgressUpdate = DateTime.MinValue;
@@ -387,8 +387,7 @@ namespace VDF.Core {
 					if (aiEmbeddingPipeline != null) {
 						// The bounded queue keeps this drain short, but on a slow CPU a few
 						// hundred frames can still be pending — give the wait its own stage.
-						currentStageLabel = T("Scan.Stage.AiEmbedding");
-						InitProgress(1);
+						InitProgress(1, T("Scan.Stage.AiEmbedding"));
 						await aiEmbeddingPipeline.CompleteAsync();
 						IncrementProgress(string.Empty);
 						Logger.Instance.Info($"AI embeddings computed for this scan: {aiEmbeddingPipeline.EmbeddedCount}");
@@ -1030,8 +1029,8 @@ namespace VDF.Core {
 
 		async Task GatherInfos() {
 			try {
-				currentStageLabel = string.Empty; // per-file analysis reports its own sub-stages
-				InitProgress(DatabaseUtils.Database.Count);
+				// per-file analysis reports its own sub-stages
+				InitProgress(DatabaseUtils.Database.Count, "");
 				// Only in-scope entries count toward a drive's done/total — out-of-scope ones
 				// are skipped in microseconds and would otherwise dilute the drive bars.
 				bool CountsTowardDriveProgress(FileEntry entry) =>
@@ -1682,8 +1681,7 @@ namespace VDF.Core {
 			int matchingParallelism = MatchingParallelDegree;
 			Logger.Instance.Info($"Matching concurrency: {matchingParallelism} worker(s) on {Environment.ProcessorCount} logical processor(s) (configured: matching={Settings.MatchingMaxDegreeOfParallelism}, media reads={Settings.MaxDegreeOfParallelism})");
 
-			currentStageLabel = T("Scan.Stage.ComparingDuplicates");
-			InitProgress(ScanList.Count);
+			InitProgress(ScanList.Count, T("Scan.Stage.ComparingDuplicates"));
 
 			// Duration buckets are keyed by whole seconds to keep percent-based tolerance intact.
 			const int bucketSizeSeconds = 1;
@@ -2074,8 +2072,7 @@ namespace VDF.Core {
 			Logger.Instance.Info($"Partial clip detection: comparing {videos.Count} video(s) (fingerprint blocks: min={videos.Min(e => e.AudioFingerprint!.Length)}, max={videos.Max(e => e.AudioFingerprint!.Length)})...");
 
 			float simThreshold = (float)Settings.PartialClipSimilarityThreshold;
-			currentStageLabel = T("Scan.Stage.PartialCompare");
-			InitProgress(videos.Count - 1);
+			InitProgress(videos.Count - 1, T("Scan.Stage.PartialCompare"));
 
 			(var matches, int pairsChecked) = CollectPartialMatchCandidates(videos,
 				pairPrefilter: (i, j) => {
@@ -2207,8 +2204,7 @@ namespace VDF.Core {
 			List<(int sourceIdx, int clipIdx, float sim, int offsetSec, Guid groupId)> assignments,
 			Func<FileEntry, FileEntry, int, (bool pass, float visualSim)> verify) {
 
-			currentStageLabel = T("Scan.Stage.PartialVisualVerify");
-			InitProgress(assignments.Count);
+			InitProgress(assignments.Count, T("Scan.Stage.PartialVisualVerify"));
 
 			int beforeCount = assignments.Count;
 			int dropped = 0;

--- a/VDF.Core/ScanEngine_AiPartial.cs
+++ b/VDF.Core/ScanEngine_AiPartial.cs
@@ -49,8 +49,7 @@ namespace VDF.Core {
 			// videos and loading the keyframe sidecar are silent minutes on a large library,
 			// and leaving the previous phase's label ("verifying partial clips") plus its
 			// finished counters on screen made that read as a hang (#865, same lesson as #831).
-			currentStageLabel = T("Scan.Stage.AiPrepare");
-			InitProgress(1);
+			InitProgress(1, T("Scan.Stage.AiPrepare"));
 
 			var alreadyGrouped = BuildAlreadyGroupedPathSet();
 
@@ -70,8 +69,7 @@ namespace VDF.Core {
 			var store = DenseEmbeddingStore.Load();
 			if (store.Count > 0)
 				Logger.Instance.Info($"AI partial detection: keyframe cache loaded ({store.Count:N0} record(s)).");
-			currentStageLabel = T("Scan.Stage.AiDenseSampling");
-			InitProgress(videos.Count);
+			InitProgress(videos.Count, T("Scan.Stage.AiDenseSampling"));
 			var dense = new DenseEmbeddingStore.DenseRecord?[videos.Count];
 			int extracted = 0, cached = 0, failed = 0;
 			using (var embedder = new OnnxEmbedder(AiComponents.ModelPath)) {
@@ -198,8 +196,7 @@ namespace VDF.Core {
 			// evicted videos the earlier passes had just grouped.
 			// Its own stage: writing a multi-gigabyte sidecar is minutes of silence that
 			// otherwise sat behind the sampling phase's completed counters (#865).
-			currentStageLabel = T("Scan.Stage.AiPersist");
-			InitProgress(1);
+			InitProgress(1, T("Scan.Stage.AiPersist"));
 			store.Save(AllDatabasePaths());
 			IncrementProgress(string.Empty);
 			if (cancelationTokenSource.IsCancellationRequested)
@@ -216,8 +213,7 @@ namespace VDF.Core {
 			for (int i = 0; i < videos.Count; i++)
 				if (dense[i] is { } record)
 					signatures[i] = ComputeDenseSignatures(record);
-			currentStageLabel = T("Scan.Stage.AiPartialCompare");
-			InitProgress(Math.Max(videos.Count - 1, 1));
+			InitProgress(Math.Max(videos.Count - 1, 1), T("Scan.Stage.AiPartialCompare"));
 			(var matches, int pairsChecked) = CollectPartialMatchCandidates(videos,
 				pairPrefilter: (i, j) => dense[i] != null && dense[j] != null,
 				tryMatchPair: (i, j) =>


### PR DESCRIPTION
This PR deduplicates and merges much of the progress reporting logic done in `ScanEngine`, which should resolve #868, then extracts it from `ScanEngine`.

The first commit is just a minor cleanup. The second is the refactoring. The third then extracts all possible logic from `ScanEngine` into a new type and replaces the struct used for snapshots with a record. It being a record updated using `x with {}` means only values that might change need to be applied by callers, and being an immutable reference type means all the locks can go. Switching to a new type means the signature of the `ScanEngine.Progress` event changes, but all the fields are identical.

It's possible that after the extraction the update logic could be cleaner (removing some of the private fields in `ScanEngine` reapplied to updates would be nice) but I didn't feel up to tracking down all the flows and calls to verify that.

If you don't want the extraction part, or want it PR'd separately, just let me know and I'll drop it from this.