### PR TITLE
Add & apply `.editorconfig` fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -100,6 +100,7 @@ csharp_style_expression_bodied_methods = true:suggestion
 csharp_style_expression_bodied_operators = true:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_namespace_declarations = block_scoped:suggestion
 csharp_style_pattern_local_over_anonymous_function = true:suggestion
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -109,6 +109,7 @@ csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = false:none
 csharp_style_var_when_type_is_apparent = true:suggestion
 file_header_template = /*\n    Copyright (C) 2026 0x90d\n    This file is part of VideoDuplicateFinder\n    VideoDuplicateFinder is free software: you can redistribute it and/or modify\n    it under the terms of the GNU Affero General Public License as published by\n    the Free Software Foundation, either version 3 of the License, or\n    (at your option) any later version.\n    VideoDuplicateFinder is distributed in the hope that it will be useful,\n    but WITHOUT ANY WARRANTY without even the implied warranty of\n    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n    GNU Affero General Public License for more details.\n    You should have received a copy of the GNU Affero General Public License\n    along with VideoDuplicateFinder.  If not, see <https://www.gnu.org/licenses/>.\n*/\n
+trim_trailing_whitespace = true
 
 [*.vb]
 #visual_basic_preferred_modifier_order =

--- a/FakeDatabaseGenerator/Program.cs
+++ b/FakeDatabaseGenerator/Program.cs
@@ -19,14 +19,14 @@ using VDF.Core;
 
 namespace FakeDatabaseGenerator {
 	internal static class Program {
-		private const int DefaultEntries = 50_000;
-		private const int DefaultSeed = 42;
-		private const int DefaultThumbnailCount = 1;
-		private const double DefaultMinDurationSeconds = 5;
-		private const double DefaultMaxDurationSeconds = 3600;
-		private const int DefaultDuplicateGroups = 0;
-		private const int DefaultDuplicateGroupSize = 2;
-		private const int GrayBytesSize = 32 * 32;
+		const int DefaultEntries = 50_000;
+		const int DefaultSeed = 42;
+		const int DefaultThumbnailCount = 1;
+		const double DefaultMinDurationSeconds = 5;
+		const double DefaultMaxDurationSeconds = 3600;
+		const int DefaultDuplicateGroups = 0;
+		const int DefaultDuplicateGroupSize = 2;
+		const int GrayBytesSize = 32 * 32;
 
 		public static int Main(string[] args) {
 			var options = ParseArgs(args);
@@ -67,7 +67,7 @@ namespace FakeDatabaseGenerator {
 			return 0;
 		}
 
-		private static FileEntry CreateEntry(Random random, Options options, List<double> positions, int index) {
+		static FileEntry CreateEntry(Random random, Options options, List<double> positions, int index) {
 			double durationSeconds = options.MinDurationSeconds +
 				random.NextDouble() * (options.MaxDurationSeconds - options.MinDurationSeconds);
 			var entry = new FileEntry {
@@ -86,7 +86,7 @@ namespace FakeDatabaseGenerator {
 			return entry;
 		}
 
-		private static FileEntry CloneEntry(FileEntry reference, int index) {
+		static FileEntry CloneEntry(FileEntry reference, int index) {
 			var clone = new FileEntry {
 				Path = Path.Combine(Path.GetDirectoryName(reference.Path) ?? string.Empty, $"fake_dup_{index:D6}.mp4"),
 				FileSize = reference.FileSize,
@@ -109,7 +109,7 @@ namespace FakeDatabaseGenerator {
 			return clone;
 		}
 
-		private static MediaInfo BuildMediaInfo(double durationSeconds, Random random) {
+		static MediaInfo BuildMediaInfo(double durationSeconds, Random random) {
 			return new MediaInfo {
 				Duration = TimeSpan.FromSeconds(durationSeconds),
 				Streams = new[] {
@@ -131,13 +131,13 @@ namespace FakeDatabaseGenerator {
 			};
 		}
 
-		private static byte[] RandomGrayBytes(Random random) {
+		static byte[] RandomGrayBytes(Random random) {
 			var bytes = new byte[GrayBytesSize];
 			random.NextBytes(bytes);
 			return bytes;
 		}
 
-		private static List<double> BuildPositions(int thumbnailCount) {
+		static List<double> BuildPositions(int thumbnailCount) {
 			var positions = new List<double>(thumbnailCount);
 			double positionCounter = 0;
 			for (int i = 0; i < thumbnailCount; i++) {
@@ -147,7 +147,7 @@ namespace FakeDatabaseGenerator {
 			return positions;
 		}
 
-		private static Options ParseArgs(string[] args) {
+		static Options ParseArgs(string[] args) {
 			var options = new Options {
 				Entries = DefaultEntries,
 				Seed = DefaultSeed,
@@ -206,28 +206,28 @@ namespace FakeDatabaseGenerator {
 			return options;
 		}
 
-		private static int ParseInt(string[] args, ref int index, string name) {
+		static int ParseInt(string[] args, ref int index, string name) {
 			if (index + 1 >= args.Length)
 				throw new ArgumentException($"Missing value for {name}");
 			index++;
 			return int.Parse(args[index], CultureInfo.InvariantCulture);
 		}
 
-		private static double ParseDouble(string[] args, ref int index, string name) {
+		static double ParseDouble(string[] args, ref int index, string name) {
 			if (index + 1 >= args.Length)
 				throw new ArgumentException($"Missing value for {name}");
 			index++;
 			return double.Parse(args[index], CultureInfo.InvariantCulture);
 		}
 
-		private static string ParseString(string[] args, ref int index, string name) {
+		static string ParseString(string[] args, ref int index, string name) {
 			if (index + 1 >= args.Length)
 				throw new ArgumentException($"Missing value for {name}");
 			index++;
 			return args[index];
 		}
 
-		private static void PrintHelp() {
+		static void PrintHelp() {
 			Console.WriteLine("FakeDatabaseGenerator");
 			Console.WriteLine("Usage:");
 			Console.WriteLine("  dotnet run --project tools/FakeDatabaseGenerator/FakeDatabaseGenerator.csproj -- [options]");
@@ -245,7 +245,7 @@ namespace FakeDatabaseGenerator {
 			Console.WriteLine("  --help, -h                  Show this help");
 		}
 
-		private sealed class Options {
+		sealed class Options {
 			public int Entries { get; set; }
 			public int Seed { get; set; }
 			public int ThumbnailCount { get; set; }

--- a/VDF.Core.Tests/FingerprintCancellationTests.cs
+++ b/VDF.Core.Tests/FingerprintCancellationTests.cs
@@ -22,7 +22,7 @@
 namespace VDF.Core.Tests;
 
 public class FingerprintCancellationTests {
-	private static string CreateTempVideo() {
+	static string CreateTempVideo() {
 		string path = Path.Combine(Path.GetTempPath(), $"vdf-cancel-test-{Guid.NewGuid():N}.mp4");
 		File.WriteAllBytes(path, Array.Empty<byte>());
 		return path;

--- a/VDF.Core/Chromaprint/ChromaContext.cs
+++ b/VDF.Core/Chromaprint/ChromaContext.cs
@@ -40,26 +40,26 @@ namespace VDF.Core.Chromaprint {
 		// ──────────────────────────────────────────────────────────────────────
 		// Frame / hop parameters  (standard Chromaprint / AcoustID values)
 		// ──────────────────────────────────────────────────────────────────────
-		private const int FrameHop = 1365; // samples between consecutive frames
+		const int FrameHop = 1365; // samples between consecutive frames
 		// Frames per second = 11025 / 1365 ≈ 8.07
 
 		// ──────────────────────────────────────────────────────────────────────
 		// Pipeline objects  (allocated once, reused across Start/Finish cycles)
 		// ──────────────────────────────────────────────────────────────────────
-		private readonly Chroma _chroma = new();
-		private readonly ChromaFilter _filter = new();
-		private readonly double[] _chromaBuf = new double[12];
-		private readonly double[] _filteredBuf = new double[12];
+		readonly Chroma _chroma = new();
+		readonly ChromaFilter _filter = new();
+		readonly double[] _chromaBuf = new double[12];
+		readonly double[] _filteredBuf = new double[12];
 
 		// ──────────────────────────────────────────────────────────────────────
 		// Per-scan state
 		// ──────────────────────────────────────────────────────────────────────
-		private short[] _samples = Array.Empty<short>();
-		private int _sampleCount;
+		short[] _samples = Array.Empty<short>();
+		int _sampleCount;
 
-		private readonly List<uint> _secondFrames = new(16);
-		private readonly List<uint> _aggregated = new();
-		private int _frameIndex;
+		readonly List<uint> _secondFrames = new(16);
+		readonly List<uint> _aggregated = new();
+		int _frameIndex;
 
 		/// <summary>Reset state and prepare for a new file.</summary>
 		public void Start() {
@@ -111,7 +111,7 @@ namespace VDF.Core.Chromaprint {
 		// Private helpers
 		// ──────────────────────────────────────────────────────────────────────
 
-		private void ProcessFrames() {
+		void ProcessFrames() {
 			Span<double> frameBuf = stackalloc double[Chroma.FrameSize];
 			int pos = 0;
 

--- a/VDF.Core/Chromaprint/Pipeline/Chroma.cs
+++ b/VDF.Core/Chromaprint/Pipeline/Chroma.cs
@@ -28,18 +28,18 @@ namespace VDF.Core.Chromaprint.Pipeline {
 		internal const int SampleRate = 11025;
 
 		// Frequency range matching the standard Chromaprint algorithm
-		private const double MinFreq = 27.5;   // A0
-		private const double MaxFreq = 3520.0; // A7
+		const double MinFreq = 27.5;   // A0
+		const double MaxFreq = 3520.0; // A7
 
-		private static readonly double[] s_hannWindow = BuildHannWindow(FrameSize);
+		static readonly double[] s_hannWindow = BuildHannWindow(FrameSize);
 
 		// Maps each FFT bin index to a chroma class (0–11), or -1 to skip.
-		private static readonly int[] s_chromaMap = BuildChromaMap();
+		static readonly int[] s_chromaMap = BuildChromaMap();
 
-		private readonly double[] _re = new double[FrameSize];
-		private readonly double[] _im = new double[FrameSize];
+		readonly double[] _re = new double[FrameSize];
+		readonly double[] _im = new double[FrameSize];
 
-		private static double[] BuildHannWindow(int n) {
+		static double[] BuildHannWindow(int n) {
 			var w = new double[n];
 			double factor = 2.0 * Math.PI / (n - 1);
 			for (int i = 0; i < n; i++)
@@ -47,7 +47,7 @@ namespace VDF.Core.Chromaprint.Pipeline {
 			return w;
 		}
 
-		private static int[] BuildChromaMap() {
+		static int[] BuildChromaMap() {
 			int bins = FrameSize / 2 + 1;
 			var map = new int[bins];
 			Array.Fill(map, -1);

--- a/VDF.Core/Chromaprint/Pipeline/ChromaFilter.cs
+++ b/VDF.Core/Chromaprint/Pipeline/ChromaFilter.cs
@@ -24,15 +24,15 @@ namespace VDF.Core.Chromaprint.Pipeline {
 	/// triangular-shaped response that smooths transient noise while preserving pitch.
 	/// </summary>
 	internal sealed class ChromaFilter {
-		private const int FilterSize = 5;
-		private const double FilterNorm = 2.50; // sum of coefficients
+		const int FilterSize = 5;
+		const double FilterNorm = 2.50; // sum of coefficients
 
-		private static readonly double[] s_coeff = { 0.25, 0.50, 1.00, 0.50, 0.25 };
+		static readonly double[] s_coeff = { 0.25, 0.50, 1.00, 0.50, 0.25 };
 
 		// Ring buffer: stores 12 doubles per slot rather than array references.
-		private readonly double[,] _ring = new double[FilterSize, 12];
-		private int _head;
-		private int _count;
+		readonly double[,] _ring = new double[FilterSize, 12];
+		int _head;
+		int _count;
 
 		internal void Reset() {
 			Array.Clear(_ring);

--- a/VDF.Core/Chromaprint/Pipeline/ChromaNormalizer.cs
+++ b/VDF.Core/Chromaprint/Pipeline/ChromaNormalizer.cs
@@ -19,7 +19,7 @@ namespace VDF.Core.Chromaprint.Pipeline {
 
 	/// <summary>L2-normalises a 12-element chroma vector in-place.</summary>
 	internal static class ChromaNormalizer {
-		private const double Epsilon = 1e-10;
+		const double Epsilon = 1e-10;
 
 		internal static void Normalize(double[] chroma) {
 			double sumSq = 0.0;

--- a/VDF.Core/Chromaprint/Pipeline/FingerprintCalculator.cs
+++ b/VDF.Core/Chromaprint/Pipeline/FingerprintCalculator.cs
@@ -30,9 +30,9 @@ namespace VDF.Core.Chromaprint.Pipeline {
 	/// Same audio → same bits; similar audio → low Hamming distance.
 	/// </summary>
 	internal static class FingerprintCalculator {
-		private static readonly (int A, int B)[] s_pairs = BuildPairs();
+		static readonly (int A, int B)[] s_pairs = BuildPairs();
 
-		private static (int, int)[] BuildPairs() {
+		static (int, int)[] BuildPairs() {
 			var pairs = new List<(int, int)>(32);
 			for (int i = 0; i < 12; i++) pairs.Add((i, (i + 1) % 12));  // adjacent
 			for (int i = 0; i < 12; i++) pairs.Add((i, (i + 3) % 12));  // minor third

--- a/VDF.Core/DuplicateFlags.cs
+++ b/VDF.Core/DuplicateFlags.cs
@@ -16,8 +16,7 @@
 
 namespace VDF.Core {
 	[Flags]
-	public enum DuplicateFlags : short
-	{
+	public enum DuplicateFlags : short {
 		None = 0,
 		Flipped = 1,
 		PartialClip = 2,  // This item is a partial clip (audio- or AI-matched) of another item in the same group

--- a/VDF.Core/FFTools/ChromaprintEngine.cs
+++ b/VDF.Core/FFTools/ChromaprintEngine.cs
@@ -28,14 +28,15 @@ namespace VDF.Core.FFTools {
 	/// audio fingerprint stored as an array of aggregated 1-second <c>uint</c> blocks.
 	/// </summary>
 	internal static class ChromaprintEngine {
-		private const int TimeoutMs = 30_000; // 30 seconds max for process exit after stream ends
+		const int TimeoutMs = 30_000; // 30 seconds max for process exit after stream ends
 		// Max time one read may wait for the next PCM chunk before the child counts as wedged.
-		private const int StallTimeoutMs = 120_000;
-		private const int TargetSampleRate = 11025;
-		private const int TargetChannels = 1;
+		const int StallTimeoutMs = 120_000;
+		const int TargetSampleRate = 11025;
+
+		const int TargetChannels = 1;
 		// Read PCM in 32 KB chunks — keeps memory low while giving ChromaContext
 		// enough samples to process multiple frames per iteration.
-		private const int ReadBufferSize = 32_768;
+		const int ReadBufferSize = 32_768;
 
 		/// <summary>
 		/// Extracts the audio fingerprint for <paramref name="filePath"/>.
@@ -57,7 +58,7 @@ namespace VDF.Core.FFTools {
 		}
 
 		/// <summary>Native path: uses FFmpeg.AutoGen bindings — no process spawning.</summary>
-		private static uint[]? ExtractFingerprintNative(string filePath, bool extendedLogging, CancellationToken ct, Action<double>? onProgress) {
+		static uint[]? ExtractFingerprintNative(string filePath, bool extendedLogging, CancellationToken ct, Action<double>? onProgress) {
 			var sw = extendedLogging ? Stopwatch.StartNew() : null;
 
 			// Suppress noisy FFmpeg warnings (e.g. AAC "Could not update timestamps
@@ -99,7 +100,7 @@ namespace VDF.Core.FFTools {
 		}
 
 		/// <summary>CLI fallback: spawns an FFmpeg process and streams PCM from stdout.</summary>
-		private static uint[]? ExtractFingerprintProcess(string filePath, bool extendedLogging, CancellationToken ct) {
+		static uint[]? ExtractFingerprintProcess(string filePath, bool extendedLogging, CancellationToken ct) {
 			var psi = new ProcessStartInfo {
 				FileName = FfmpegEngine.FFmpegPath,
 				CreateNoWindow = true,
@@ -239,7 +240,7 @@ namespace VDF.Core.FFTools {
 			}
 		}
 
-		private static void KillProcess(Process process) {
+		static void KillProcess(Process process) {
 			try {
 				if (!process.HasExited)
 					process.Kill();

--- a/VDF.Core/FFTools/FFmpegNative/AudioStreamDecoder.cs
+++ b/VDF.Core/FFTools/FFmpegNative/AudioStreamDecoder.cs
@@ -26,18 +26,18 @@ namespace VDF.Core.FFTools.FFmpegNative {
 	/// they become available.  Modelled after <see cref="VideoStreamDecoder"/>.
 	/// </summary>
 	unsafe sealed class AudioStreamDecoder : IDisposable {
-		private AVFormatContext* _pFormatContext;
-		private AVCodecContext* _pCodecContext;
-		private SwrContext* _pSwrContext;
-		private AVFrame* _pFrame;
-		private AVPacket* _pPacket;
-		private readonly int _streamIndex;
-		private readonly AVIOInterruptCB_callback _interruptCbDelegate;
-		private readonly long _timeoutTicks;
-		private long _deadlineTicks;
-		private CancellationToken _ct;
+		AVFormatContext* _pFormatContext;
+		AVCodecContext* _pCodecContext;
+		SwrContext* _pSwrContext;
+		AVFrame* _pFrame;
+		AVPacket* _pPacket;
+		readonly int _streamIndex;
+		readonly AVIOInterruptCB_callback _interruptCbDelegate;
+		readonly long _timeoutTicks;
+		long _deadlineTicks;
+		CancellationToken _ct;
 
-		private const AVSampleFormat TargetFormat = AVSampleFormat.AV_SAMPLE_FMT_S16;
+		const AVSampleFormat TargetFormat = AVSampleFormat.AV_SAMPLE_FMT_S16;
 
 		// Input layout the resampler is currently configured for. Corrupt streams (e.g. an
 		// AAC channel-config change mid-stream, issue #861) can emit frames whose layout
@@ -45,12 +45,12 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		// swresample read plane pointers that do not exist — a native access violation
 		// that kills the whole process. DecodeAll() compares every frame against these
 		// and rebuilds the resampler on mismatch.
-		private int _swrInFormat;
-		private int _swrInSampleRate;
-		private int _swrInChannels;
+		int _swrInFormat;
+		int _swrInSampleRate;
+		int _swrInChannels;
 
 		// Reusable output buffer for resampled PCM (grown as needed, avoids per-frame allocation)
-		private byte[] _outBuf = new byte[8192];
+		byte[] _outBuf = new byte[8192];
 
 		/// <summary>True if the file contained a usable audio stream.</summary>
 		public bool HasAudioStream { get; }
@@ -58,7 +58,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		/// <summary>Total stream duration in seconds, or 0 when unknown.</summary>
 		public double DurationSeconds { get; private set; }
 
-		private readonly int _targetSampleRate;
+		readonly int _targetSampleRate;
 
 		public AudioStreamDecoder(string url, int targetSampleRate, CancellationToken ct = default, int timeoutMs = 120_000) {
 			_targetSampleRate = targetSampleRate;
@@ -137,7 +137,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		/// (Re)creates the SwrContext for the given input layout and records the layout so
 		/// <see cref="DecodeAll"/> can detect frames that no longer match it.
 		/// </summary>
-		private void CreateResampler(AVChannelLayout inLayout, AVSampleFormat inFormat, int inSampleRate) {
+		void CreateResampler(AVChannelLayout inLayout, AVSampleFormat inFormat, int inSampleRate) {
 			if (_pSwrContext != null) {
 				SwrContext* old = _pSwrContext;
 				ffmpeg.swr_free(&old);
@@ -187,7 +187,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		/// (corrupt) stream changed layout mid-decode. Returns the samples flushed out of the
 		/// old resampler, or -1 when the frame is garbage and must be skipped.
 		/// </summary>
-		private int EnsureResamplerMatchesFrame(Action<ReadOnlySpan<short>> onSamples) {
+		int EnsureResamplerMatchesFrame(Action<ReadOnlySpan<short>> onSamples) {
 			int frameFormat = _pFrame->format;
 			int frameRate = _pFrame->sample_rate;
 			int frameChannels = _pFrame->ch_layout.nb_channels;
@@ -293,7 +293,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		/// Resamples audio from <paramref name="inputData"/> (or flushes the resampler
 		/// when <paramref name="inputData"/> is null) and delivers the result via callback.
 		/// </summary>
-		private int ConvertAndDeliver(byte** inputData, int inputSamples, Action<ReadOnlySpan<short>> onSamples) {
+		int ConvertAndDeliver(byte** inputData, int inputSamples, Action<ReadOnlySpan<short>> onSamples) {
 			int outSamples = ffmpeg.swr_get_out_samples(_pSwrContext, inputSamples);
 			if (outSamples <= 0) return 0;
 

--- a/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
+++ b/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
@@ -25,7 +25,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 		static readonly WindowsFunctionResolver windowsFunctionResolver = new();
 		static readonly MacFunctionResolver macFunctionResolver = new();
 
-		private static bool ffmpegLibraryFound;
+		static bool ffmpegLibraryFound;
 		public static unsafe string? Av_strerror(int error) {
 			const int bufferSize = 1024;
 			byte* buffer = stackalloc byte[bufferSize];
@@ -40,7 +40,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			return error;
 		}
 
-		private static bool FindFFmpegLibraryFiles() {
+		static bool FindFFmpegLibraryFiles() {
 			try {
 
 				string? path = FFToolsUtils.GetPath(FFToolsUtils.FFTool.FFmpeg);

--- a/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
+++ b/VDF.Core/FFTools/FFmpegNative/FFmpegHelper.cs
@@ -241,7 +241,7 @@ namespace VDF.Core.FFTools.FFmpegNative {
 			ffmpeg.RootPath = path;
 			return true;
 		}
-		
+
 		public static string[] GenerateLibraryFileNames() =>
 			ffmpeg.LibraryVersionMap
 				.Select(item => {

--- a/VDF.Core/FFTools/FFmpegNative/VideoFrameConverter.cs
+++ b/VDF.Core/FFTools/FFmpegNative/VideoFrameConverter.cs
@@ -18,10 +18,10 @@ using FFmpeg.AutoGen;
 
 namespace VDF.Core.FFTools.FFmpegNative {
 	sealed unsafe class VideoFrameConverter : IDisposable {
-		private readonly AVFrame* _pConvertedFrame;
-		private readonly SwsContext* _pConvertContext;
-		private readonly Size _sourceSize;
-		private readonly AVPixelFormat _sourcePixelFormat;
+		readonly AVFrame* _pConvertedFrame;
+		readonly SwsContext* _pConvertContext;
+		readonly Size _sourceSize;
+		readonly AVPixelFormat _sourcePixelFormat;
 
 		public enum ScaleQuality {
 			FastBilinear,

--- a/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
+++ b/VDF.Core/FFTools/FFmpegNative/VideoStreamDecoder.cs
@@ -19,15 +19,15 @@ using FFmpeg.AutoGen;
 
 namespace VDF.Core.FFTools.FFmpegNative {
 	unsafe class VideoStreamDecoder : IDisposable {
-		private AVCodecContext* _pCodecContext;
-		private AVFormatContext* _pFormatContext;
-		private AVFrame* _pFrame;
-		private AVPacket* _pPacket;
-		private AVFrame* _pReceivedFrame;
-		private readonly int _streamIndex;
-		private readonly AVIOInterruptCB_callback _interruptCbDelegate;
-		private readonly long _timeoutTicks;
-		private long _deadlineTicks;
+		AVCodecContext* _pCodecContext;
+		AVFormatContext* _pFormatContext;
+		AVFrame* _pFrame;
+		AVPacket* _pPacket;
+		AVFrame* _pReceivedFrame;
+		readonly int _streamIndex;
+		readonly AVIOInterruptCB_callback _interruptCbDelegate;
+		readonly long _timeoutTicks;
+		long _deadlineTicks;
 
 		public VideoStreamDecoder(string url, AVHWDeviceType HWDeviceType = AVHWDeviceType.AV_HWDEVICE_TYPE_NONE, int timeoutMs = 15_000) {
 			_pFormatContext = ffmpeg.avformat_alloc_context();

--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -1103,7 +1103,7 @@ namespace VDF.Core.FFTools {
 			return kept.Count == 0 ? string.Empty : Environment.NewLine + string.Join(Environment.NewLine, kept);
 		}
 
-		private static List<string> TokenizeArgs(string args) {
+		static List<string> TokenizeArgs(string args) {
 			var tokens = new List<string>();
 			var current = new System.Text.StringBuilder();
 			bool inQuotes = false;

--- a/VDF.Core/FileEntry.cs
+++ b/VDF.Core/FileEntry.cs
@@ -34,7 +34,7 @@ namespace VDF.Core {
 			_Path = fileInfo.FullName;
 			Folder = fileInfo.Directory?.FullName ?? string.Empty;
 			var extension = fileInfo.Extension;
-			IsImage = FileUtils.ImageExtensions.Any(x => extension.EndsWith(x, StringComparison.OrdinalIgnoreCase));			
+			IsImage = FileUtils.ImageExtensions.Any(x => extension.EndsWith(x, StringComparison.OrdinalIgnoreCase));
 			DateCreated = fileInfo.CreationTimeUtc;
 			DateModified = fileInfo.LastWriteTimeUtc;
 			FileSize = fileInfo.Length;
@@ -57,7 +57,7 @@ namespace VDF.Core {
 				_Path = fileInfo.FullName;
 				Folder = fileInfo.Directory?.FullName ?? string.Empty;
 			}
-		 }
+		}
 		[MemoryPackOrder(1)]
 		public string Folder;
 		[MemoryPackOrder(2)]

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -860,8 +860,7 @@ namespace VDF.Core {
 				reason = "file is marked as too dark";
 				return true;
 			}
-			if (!Settings.IncludeMissingFiles && !File.Exists(entry.Path))
-			{
+			if (!Settings.IncludeMissingFiles && !File.Exists(entry.Path)) {
 				reason = "file does not exist";
 				return true;
 			}
@@ -988,7 +987,7 @@ namespace VDF.Core {
 			}
 			// Wildcard pattern without path separators: match against each individual segment of folderPath
 			bool hasSeparator = blacklistEntry.Contains(Path.DirectorySeparatorChar) ||
-			                    blacklistEntry.Contains(Path.AltDirectorySeparatorChar);
+								blacklistEntry.Contains(Path.AltDirectorySeparatorChar);
 			if (!hasSeparator) {
 				string[] segments = folderPath.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
 					StringSplitOptions.RemoveEmptyEntries);

--- a/VDF.Core/Utils/HardLinkUtils.cs
+++ b/VDF.Core/Utils/HardLinkUtils.cs
@@ -118,7 +118,7 @@ namespace VDF.Core.Utils {
 			if (!TryGetFileIdWindows(filepath, out var fileA)) {
 				return FallbackWindows(filepath, otherFilepath);
 			}
-			if ( !TryGetFileIdWindows(otherFilepath, out var fileB)) {
+			if (!TryGetFileIdWindows(otherFilepath, out var fileB)) {
 				return FallbackWindows(filepath, otherFilepath);
 			}
 

--- a/VDF.Core/Utils/HardLinkUtils.cs
+++ b/VDF.Core/Utils/HardLinkUtils.cs
@@ -77,7 +77,7 @@ namespace VDF.Core.Utils {
 		}
 
 		[StructLayout(LayoutKind.Sequential)]
-		private struct BY_HANDLE_FILE_INFORMATION {
+		struct BY_HANDLE_FILE_INFORMATION {
 			public uint FileAttributes;
 			public FILETIME CreationTime;
 			public FILETIME LastAccessTime;
@@ -90,7 +90,7 @@ namespace VDF.Core.Utils {
 			public uint FileIndexLow;
 		}
 		[StructLayout(LayoutKind.Sequential)]
-		private struct FILETIME {
+		struct FILETIME {
 			public uint dwLowDateTime;
 			public uint dwHighDateTime;
 		}

--- a/VDF.Core/pHash/PHashCompare.cs
+++ b/VDF.Core/pHash/PHashCompare.cs
@@ -36,7 +36,7 @@ namespace VDF.Core.pHash {
 		/// <param name="strict">true → floor (at least X%); strict=false → round (approximately X%)</param>
 		/// <returns></returns>
 		/// <exception cref="ArgumentOutOfRangeException"></exception>
-		public static bool IsDuplicateByPercent(ulong a, ulong b, out float similarity, double percent = 0.90,  bool strict = true) {
+		public static bool IsDuplicateByPercent(ulong a, ulong b, out float similarity, double percent = 0.90, bool strict = true) {
 			if (percent < 0 || percent > 1) throw new ArgumentOutOfRangeException(nameof(percent));
 			int d = Hamming(a, b);
 			similarity = 1f - (d / 64f);

--- a/VDF.Core/pHash/PerceptualHash.cs
+++ b/VDF.Core/pHash/PerceptualHash.cs
@@ -25,14 +25,14 @@ using System.Threading.Tasks;
 namespace VDF.Core.pHash {
 	internal static class PerceptualHash {
 
-		private const int N = 32;      // working size
-		private const int K = 8;       // low-frequency block size (1..8,1..8)
+		const int N = 32;      // working size
+		const int K = 8;       // low-frequency block size (1..8,1..8)
 
 		// Cosine table flattened to 1D: Cos[k, i] is now Cos[k * N + i]. Faster than
 		// float[,] (one bounds check instead of two) and lets dot-product loops index
 		// linearly. Precomputed once at static init.
-		private static readonly float[] Cos = BuildCos(N);
-		private static readonly float[] Alpha = BuildAlpha(N);
+		static readonly float[] Cos = BuildCos(N);
+		static readonly float[] Alpha = BuildAlpha(N);
 
 		public static ulong ComputePHashFromGray32x32(ReadOnlySpan<byte> gray) {
 			if (gray.Length != N * N) throw new ArgumentException("expected 32x32=1024 bytes");
@@ -92,7 +92,7 @@ namespace VDF.Core.pHash {
 		}
 
 
-		private static float[] BuildCos(int n) {
+		static float[] BuildCos(int n) {
 			var t = new float[n * n];
 			for (int k = 0; k < n; k++)
 				for (int i = 0; i < n; i++)
@@ -100,7 +100,7 @@ namespace VDF.Core.pHash {
 			return t;
 		}
 
-		private static float[] BuildAlpha(int n) {
+		static float[] BuildAlpha(int n) {
 			var a = new float[n];
 			double invN = 1.0 / n;
 			a[0] = (float)Math.Sqrt(invN);
@@ -108,7 +108,7 @@ namespace VDF.Core.pHash {
 			return a;
 		}
 
-		private static float Median64(Span<float> values) {
+		static float Median64(Span<float> values) {
 			// Copy to the stack and sort; faster than fancy selection for 64 elems
 			Span<float> buf = stackalloc float[K * K];
 			values.CopyTo(buf);

--- a/VDF.GUI.Tests/HoverDiffTests.cs
+++ b/VDF.GUI.Tests/HoverDiffTests.cs
@@ -28,17 +28,17 @@ namespace VDF.GUI.Tests {
 
 		static DuplicateItemVM Item(TimeSpan? duration = null, int frameSizeInt = 0, long size = 0,
 				bool bestDuration = false, bool bestFrameSize = false, bool bestSize = false) => new() {
-			ItemInfo = new DuplicateItem {
-				GroupId = Guid.Empty,
-				Path = Guid.NewGuid().ToString(),
-				Duration = duration ?? TimeSpan.Zero,
-				FrameSizeInt = frameSizeInt,
-				SizeLong = size,
-				IsBestDuration = bestDuration,
-				IsBestFrameSize = bestFrameSize,
-				IsBestSize = bestSize,
-			}
-		};
+					ItemInfo = new DuplicateItem {
+						GroupId = Guid.Empty,
+						Path = Guid.NewGuid().ToString(),
+						Duration = duration ?? TimeSpan.Zero,
+						FrameSizeInt = frameSizeInt,
+						SizeLong = size,
+						IsBestDuration = bestDuration,
+						IsBestFrameSize = bestFrameSize,
+						IsBestSize = bestSize,
+					}
+				};
 
 		[Fact]
 		public void AllTied_ShowsNothing_InsteadOfBestOnEveryRow() {

--- a/VDF.GUI.Tests/SelectionExpressionTests.cs
+++ b/VDF.GUI.Tests/SelectionExpressionTests.cs
@@ -28,12 +28,12 @@ namespace VDF.GUI.Tests {
 
 		static DuplicateItem Item(string path = @"D:\videos\S01E02.mkv", string format = "jpg",
 				long size = 5000, int minutes = 20, bool isImage = false) => new() {
-			Path = path,
-			Format = format,
-			SizeLong = size,
-			Duration = TimeSpan.FromMinutes(minutes),
-			IsImage = isImage,
-		};
+					Path = path,
+					Format = format,
+					SizeLong = size,
+					Duration = TimeSpan.FromMinutes(minutes),
+					IsImage = isImage,
+				};
 
 		[Theory]
 		// The exact expressions from #844:

--- a/VDF.GUI/App.xaml.cs
+++ b/VDF.GUI/App.xaml.cs
@@ -51,9 +51,9 @@ namespace VDF.GUI {
 
 			base.OnFrameworkInitializationCompleted();
 		}
-		private void OnShutdownRequested(object? sender, ShutdownRequestedEventArgs e) => SafeCleanup();
-		private void OnExitCleanup(object? sender, ControlledApplicationLifetimeExitEventArgs e) => SafeCleanup();
-		private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e) {
+		void OnShutdownRequested(object? sender, ShutdownRequestedEventArgs e) => SafeCleanup();
+		void OnExitCleanup(object? sender, ControlledApplicationLifetimeExitEventArgs e) => SafeCleanup();
+		static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e) {
 			try {
 				string detail = e.ExceptionObject is Exception ex ? ex.ToString() : e.ExceptionObject?.ToString() ?? "<null>";
 				VDF.Core.Utils.Logger.Instance.Error($"FATAL: Unhandled exception (terminating={e.IsTerminating}): {detail}");
@@ -61,7 +61,7 @@ namespace VDF.GUI {
 			catch { /* never let logging failure mask the original crash */ }
 			SafeCleanup();
 		}
-		private static void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e) {
+		static void OnDispatcherUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e) {
 			try {
 				VDF.Core.Utils.Logger.Instance.Error($"Unhandled dispatcher exception: {e.Exception}");
 			}
@@ -69,14 +69,14 @@ namespace VDF.GUI {
 			// Keep the app alive so the user can save state and the log contains a stack trace.
 			e.Handled = true;
 		}
-		private static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e) {
+		static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs e) {
 			try {
 				VDF.Core.Utils.Logger.Instance.Error($"Unobserved task exception: {e.Exception}");
 			}
 			catch { /* never let logging failure mask the original error */ }
 			e.SetObserved();
 		}
-		private static void SafeCleanup() {
+		static void SafeCleanup() {
 			try {
 				try { VDF.GUI.Utils.ThumbCacheHelpers.Provider?.Dispose(); }
 				catch { /* ignore */ }

--- a/VDF.GUI/Data/CompareBy.cs
+++ b/VDF.GUI/Data/CompareBy.cs
@@ -22,5 +22,5 @@ using System.Threading.Tasks;
 using VDF.GUI.ViewModels;
 
 namespace VDF.GUI.Data {
-	
+
 }

--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -28,8 +28,8 @@ namespace VDF.GUI.Data {
 	public enum ThumbnailDoubleClickAction { OpenFile, OpenThumbnailComparer }
 
 	public class SettingsFile : ReactiveObject {
-		private static SettingsFile? instance;
-		private static string? settingsPath;
+		static SettingsFile? instance;
+		static string? settingsPath;
 
 		[JsonIgnore]
 		public static SettingsFile Instance => instance ??= new SettingsFile();

--- a/VDF.GUI/Data/ZoomPanPresenter.cs
+++ b/VDF.GUI/Data/ZoomPanPresenter.cs
@@ -56,14 +56,14 @@ namespace VDF.GUI.Data {
 
 		public double MinZoom { get; set; } = 0.1;
 		public double MaxZoom { get; set; } = 8.0;
-		private readonly ScaleTransform _scale = new() { ScaleX = 1, ScaleY = 1 };
-		private readonly TranslateTransform _translate = new();
-		private TransformGroup? _group;
+		readonly ScaleTransform _scale = new() { ScaleX = 1, ScaleY = 1 };
+		readonly TranslateTransform _translate = new();
+		TransformGroup? _group;
 
-		private bool _panning;
-		private bool _swiping;
-		private Point _pointerStart;
-		private double _startX, _startY;
+		bool _panning;
+		bool _swiping;
+		Point _pointerStart;
+		double _startX, _startY;
 
 		const double SwipeGrabDistance = 20;
 
@@ -84,7 +84,7 @@ namespace VDF.GUI.Data {
 			this.GetPropertyChangedObservable(OffsetYProperty).Subscribe(_ => ApplyTransform());
 		}
 
-		private void OnZoomChanged() {
+		void OnZoomChanged() {
 			// A programmatic zoom (the Zoom-In/Out/Fit toolbar commands set Zoom directly) must
 			// re-clamp the pan offsets too: an offset that was valid at the previous zoom can
 			// push the now-differently-scaled content out of the viewport, leaving blank space.
@@ -96,7 +96,7 @@ namespace VDF.GUI.Data {
 			ApplyTransform();
 		}
 
-		private void AttachTransform() {
+		void AttachTransform() {
 			if (Content is Visual v) {
 				_group ??= new TransformGroup { Children = { _scale, _translate } };
 				// Avalonia defaults RenderTransformOrigin to the center. All offset math
@@ -109,7 +109,7 @@ namespace VDF.GUI.Data {
 			}
 		}
 
-		private void ApplyTransform() {
+		void ApplyTransform() {
 			_scale.ScaleX = _scale.ScaleY = Math.Clamp(Zoom, MinZoom, MaxZoom);
 			_translate.X = OffsetX;
 			_translate.Y = OffsetY;
@@ -118,7 +118,7 @@ namespace VDF.GUI.Data {
 
 		// Avalonia converts the pointer position through the content's inverse render
 		// transform, giving the exact content pixel under the cursor at any zoom/offset.
-		private Point GetContentPosition(PointerEventArgs e) =>
+		Point GetContentPosition(PointerEventArgs e) =>
 			Content is Visual contentVisual ? e.GetPosition(contentVisual) : e.GetPosition(this);
 
 		internal static double ClampOffsetToViewport(double offset, double viewportLength, double contentLength, double zoom) {
@@ -133,7 +133,7 @@ namespace VDF.GUI.Data {
 			return Math.Clamp(offset, viewportLength - scaledLength, 0d);
 		}
 
-		private Point ClampOffsetsToViewport(double offsetX, double offsetY, double zoom) {
+		Point ClampOffsetsToViewport(double offsetX, double offsetY, double zoom) {
 			if (Content is not Visual contentVisual)
 				return new Point(offsetX, offsetY);
 			return new Point(
@@ -141,7 +141,7 @@ namespace VDF.GUI.Data {
 				ClampOffsetToViewport(offsetY, Bounds.Height, contentVisual.Bounds.Height, zoom));
 		}
 
-		private bool IsNearDivider(PointerEventArgs e) {
+		bool IsNearDivider(PointerEventArgs e) {
 			Point contentPoint = GetContentPosition(e);
 			// The grab margin is a screen-space distance; translate it into content
 			// space so the divider stays equally grabbable at any zoom level.
@@ -156,7 +156,7 @@ namespace VDF.GUI.Data {
 			}
 		}
 
-		private void OnWheel(object? s, PointerWheelEventArgs e) {
+		void OnWheel(object? s, PointerWheelEventArgs e) {
 			var oldZoom = Math.Clamp(Zoom, MinZoom, MaxZoom);
 			var factor = e.Delta.Y > 0 ? 1.1 : (1.0 / 1.1);
 			var newZoom = Math.Clamp(oldZoom * factor, MinZoom, MaxZoom);
@@ -179,7 +179,7 @@ namespace VDF.GUI.Data {
 			e.Handled = true;
 		}
 
-		private void OnPressed(object? s, PointerPressedEventArgs e) {
+		void OnPressed(object? s, PointerPressedEventArgs e) {
 			var props = e.GetCurrentPoint(this).Properties;
 
 			if (IsAnySwipe && props.IsLeftButtonPressed && IsNearDivider(e)) {
@@ -200,7 +200,7 @@ namespace VDF.GUI.Data {
 			}
 		}
 
-		private void OnReleased(object? s, PointerReleasedEventArgs e) {
+		void OnReleased(object? s, PointerReleasedEventArgs e) {
 			if (_swiping) {
 				_swiping = false;
 				e.Pointer.Capture(null);
@@ -214,7 +214,7 @@ namespace VDF.GUI.Data {
 			}
 		}
 
-		private void OnMoved(object? s, PointerEventArgs e) {
+		void OnMoved(object? s, PointerEventArgs e) {
 			if (_swiping) {
 				UpdateSwipeFromPointer(e);
 				e.Handled = true;
@@ -238,7 +238,7 @@ namespace VDF.GUI.Data {
 			}
 		}
 
-		private void UpdateSwipeFromPointer(PointerEventArgs e) {
+		void UpdateSwipeFromPointer(PointerEventArgs e) {
 			Point contentPoint = GetContentPosition(e);
 			if (SwipeVertical) {
 				var displayH = SwipeDisplayHeight;

--- a/VDF.GUI/LanguageService.cs
+++ b/VDF.GUI/LanguageService.cs
@@ -26,10 +26,10 @@ using ReactiveUI;
 
 namespace VDF.GUI {
 	public class LanguageService : ReactiveObject {
-		private Dictionary<string, string> _translations = new();
-		private string _currentLanguage = "en";
+		Dictionary<string, string> _translations = new();
+		string _currentLanguage = "en";
 
-		private IReadOnlyList<string>? _availableLanguages;
+		IReadOnlyList<string>? _availableLanguages;
 		public IReadOnlyList<string> AvailableLanguages => _availableLanguages ??= LoadAvailableLanguages();
 		public string CurrentLanguage {
 			get => _currentLanguage;

--- a/VDF.GUI/Mvvm/Converters.cs
+++ b/VDF.GUI/Mvvm/Converters.cs
@@ -239,7 +239,7 @@ namespace VDF.GUI.Mvvm {
 			=> Avalonia.Data.BindingOperations.DoNothing;
 
 		// --- helpers ---
-		private static string RemoveFormatControls(string s) {
+		static string RemoveFormatControls(string s) {
 			// Fast path: no control char present
 			bool hasCf = false;
 			foreach (var ch in s) {
@@ -255,7 +255,7 @@ namespace VDF.GUI.Mvvm {
 			return sb.ToString();
 		}
 
-		private static string RemoveIsolatedSurrogates(string s) {
+		static string RemoveIsolatedSurrogates(string s) {
 			var sb = new System.Text.StringBuilder(s.Length);
 			for (int i = 0; i < s.Length; i++) {
 				char c = s[i];

--- a/VDF.GUI/Program.cs
+++ b/VDF.GUI/Program.cs
@@ -40,8 +40,7 @@ namespace VDF.GUI {
 			rootCommand.Options.Add(settingsOption);
 
 			// This runs ONLY when parsing succeeded and no built-in action (like --help) took over
-			rootCommand.SetAction(parseResult =>
-			{
+			rootCommand.SetAction(parseResult => {
 				if (parseResult.GetValue(settingsOption) is FileInfo parsedFile) {
 					if (parsedFile.Exists) {
 						Data.SettingsFile.SetSettingsPath(parsedFile.FullName);
@@ -67,7 +66,7 @@ namespace VDF.GUI {
 		public static AppBuilder BuildAvaloniaApp()
 			=> AppBuilder.Configure<App>()
 				.UsePlatformDetect()
-				.With(new X11PlatformOptions {  UseDBusFilePicker = false })
+				.With(new X11PlatformOptions { UseDBusFilePicker = false })
 				.With(new FontManagerOptions {
 					// Without explicit fallbacks, Avalonia's default font on macOS does not
 					// resolve CJK glyphs through CoreText, producing U+FFFD replacement chars.

--- a/VDF.GUI/Utils/ConsoleAttach.cs
+++ b/VDF.GUI/Utils/ConsoleAttach.cs
@@ -23,13 +23,13 @@ using System.Threading.Tasks;
 
 namespace VDF.GUI.Utils {
 	internal static class ConsoleAttach {
-		private const uint ATTACH_PARENT_PROCESS = 0xFFFFFFFF;
+		const uint ATTACH_PARENT_PROCESS = 0xFFFFFFFF;
 
 		[DllImport("kernel32.dll", SetLastError = true)]
-		private static extern bool AttachConsole(uint dwProcessId);
+		static extern bool AttachConsole(uint dwProcessId);
 
 		[DllImport("kernel32.dll", SetLastError = true)]
-		private static extern bool AllocConsole();
+		static extern bool AllocConsole();
 
 		public static void EnsureConsole() {
 			if (!OperatingSystem.IsWindows())

--- a/VDF.GUI/Utils/PickerDialogUtils.cs
+++ b/VDF.GUI/Utils/PickerDialogUtils.cs
@@ -18,8 +18,7 @@ using Avalonia.Platform.Storage;
 
 namespace VDF.GUI.Utils {
 	internal static class PickerDialogUtils {
-
-		private static string GetLocalPath(Uri uriPath) {
+		static string GetLocalPath(Uri uriPath) {
 			if (uriPath.IsFile) {
 				// The `LocalPath` member of the `Uri` object we got
 				// from `TryGetUri()` might be wrong if the original

--- a/VDF.GUI/Utils/ThumbnailStore.cs
+++ b/VDF.GUI/Utils/ThumbnailStore.cs
@@ -93,7 +93,7 @@ namespace VDF.GUI.Utils {
 		readonly object _gate = new();
 		public readonly string Folder;
 
-		private ThumbPack(FileStream fs, string idxPath, Dictionary<string, (long, int)> idx, string packPath, string folder) {
+		ThumbPack(FileStream fs, string idxPath, Dictionary<string, (long, int)> idx, string packPath, string folder) {
 			_fs = fs; _idxPath = idxPath; _idx = idx; Folder = folder; _packPath = packPath;
 		}
 

--- a/VDF.GUI/ViewModels/DatabaseViewerVM.cs
+++ b/VDF.GUI/ViewModels/DatabaseViewerVM.cs
@@ -119,7 +119,7 @@ namespace VDF.GUI.ViewModels {
 
 	internal class DatabaseViewerVM : ReactiveObject {
 		readonly List<DatabaseEntryVM> allEntries;
-		private DatabaseWrapper DbWrapper;
+		DatabaseWrapper DbWrapper;
 		readonly string TempDatabaseFile;
 		// Only forwarded to ScanEngine.ExportDataBaseToJson (which serializes through
 		// its own typed metadata); local (de)serialization uses CoreJsonContext directly.

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -164,8 +164,7 @@ namespace VDF.GUI.ViewModels {
 			set => this.RaiseAndSetIfChanged(ref _ThumbnailGridColumns, value);
 		}
 
-		[JsonIgnore]
-		private Bitmap? _thumbnail;
+		[JsonIgnore] Bitmap? _thumbnail;
 
 		[JsonIgnore]
 		public Bitmap? Thumbnail {

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -1864,19 +1864,19 @@ Non-Windows setup:
 					item.Checked = true;
 		}
 
-	public ReactiveCommand<Unit, Unit> LoadThumbnailsForCheckedItemsCommand => ReactiveCommand.CreateFromTask(async () => {
-		var items = Duplicates.Where(d => d.Checked).Select(vm => vm.ItemInfo).ToList();
-		if (items.Count == 0) return;
-		SyncCoreSettings();
-		await Scanner.RetrieveThumbnailsForItems(items);
-	});
+		public ReactiveCommand<Unit, Unit> LoadThumbnailsForCheckedItemsCommand => ReactiveCommand.CreateFromTask(async () => {
+			var items = Duplicates.Where(d => d.Checked).Select(vm => vm.ItemInfo).ToList();
+			if (items.Count == 0) return;
+			SyncCoreSettings();
+			await Scanner.RetrieveThumbnailsForItems(items);
+		});
 
-	public ReactiveCommand<Unit, Unit> LoadThumbnailsForGroupCommand => ReactiveCommand.CreateFromTask(async () => {
-		if (GetSelectedDuplicateItem() is not DuplicateItemVM currentItem) return;
-		var items = Duplicates.Where(d => d.ItemInfo.GroupId == currentItem.ItemInfo.GroupId).Select(d => d.ItemInfo).ToList();
-		SyncCoreSettings();
-		await Scanner.RetrieveThumbnailsForItems(items);
-	});
+		public ReactiveCommand<Unit, Unit> LoadThumbnailsForGroupCommand => ReactiveCommand.CreateFromTask(async () => {
+			if (GetSelectedDuplicateItem() is not DuplicateItemVM currentItem) return;
+			var items = Duplicates.Where(d => d.ItemInfo.GroupId == currentItem.ItemInfo.GroupId).Select(d => d.ItemInfo).ToList();
+			SyncCoreSettings();
+			await Scanner.RetrieveThumbnailsForItems(items);
+		});
 
 		List<DuplicateItemVM> CheckedItemsToDelete => ScopedDuplicates().Where(d => d.Checked && d.IsVisibleInFilter).ToList();
 

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -81,7 +81,7 @@ namespace VDF.GUI.ViewModels {
 
 		public AvaloniaList<DuplicateItemVM> Duplicates { get; } = new();
 
-		private TempDir? TempDirectory;
+		TempDir? TempDirectory;
 
 		static readonly string[] BusyMessages =
 		{
@@ -106,7 +106,8 @@ namespace VDF.GUI.ViewModels {
 			App.Lang["BusyMessages19"],
 			App.Lang["BusyMessages20"]
 		};
-		private void ChangeIsBusyMessage() => IsBusyOverlayText = BusyMessages[Random.Shared.Next(BusyMessages.Length)];
+
+		void ChangeIsBusyMessage() => IsBusyOverlayText = BusyMessages[Random.Shared.Next(BusyMessages.Length)];
 
 		readonly DispatcherTimer scheduledScanTimer = new();
 		DateTime lastScheduledScanDate = DateTime.MinValue;
@@ -519,7 +520,7 @@ namespace VDF.GUI.ViewModels {
 			return (ready, !ready && wasReadyToCompare);
 		}
 
-		private void Scanner_ThumbnailProgress(int arg1, int arg2) => Dispatcher.UIThread.Post(() => {
+		void Scanner_ThumbnailProgress(int arg1, int arg2) => Dispatcher.UIThread.Post(() => {
 			ThumbnailRetrievalProgressText = $"Retrieving thumbnails for preview: {arg1}/{arg2}";
 			ThumbnailProgressCurrent = arg1;
 			ThumbnailProgressMax = arg2;
@@ -795,10 +796,10 @@ namespace VDF.GUI.ViewModels {
 			PotentialSavings = savings.BytesToString();
 		}
 
-		private DuplicateItemVM? GetSelectedDuplicateItem() =>
+		DuplicateItemVM? GetSelectedDuplicateItem() =>
 			NewResultsSelectionProvider?.Invoke().FirstOrDefault();
 
-		private List<DuplicateItemVM> GetSelectedDuplicates() =>
+		List<DuplicateItemVM> GetSelectedDuplicates() =>
 			NewResultsSelectionProvider?.Invoke() ?? new();
 
 		public static ReactiveCommand<Unit, Unit> AboutCommand => ReactiveCommand.CreateFromTask(async () => {
@@ -954,7 +955,7 @@ namespace VDF.GUI.ViewModels {
 
 		// Accepts both the v1 envelope ({version, items}) and the legacy raw array
 		// shape produced by older builds. Returns the items list.
-		private static List<DuplicateItemVM> ReadScanResultsItems(JsonElement root) {
+		static List<DuplicateItemVM> ReadScanResultsItems(JsonElement root) {
 			if (root.ValueKind == JsonValueKind.Array)
 				return root.Deserialize(GuiJsonFieldsContext.Default.ListDuplicateItemVM) ?? new();
 
@@ -1327,7 +1328,7 @@ namespace VDF.GUI.ViewModels {
 			return null;
 		}
 
-		private bool AlternativeOpen(string cmdSingle, string cmdMulti, List<DuplicateItemVM>? items = null) {
+		bool AlternativeOpen(string cmdSingle, string cmdMulti, List<DuplicateItemVM>? items = null) {
 			if (string.IsNullOrEmpty(cmdSingle) && string.IsNullOrEmpty(cmdMulti))
 				return false;
 
@@ -1793,7 +1794,7 @@ Non-Windows setup:
 			}
 		}
 
-		private HashSet<Guid> ComputeBlacklistedGroupIds(IEnumerable<(Guid GroupId, string Path)> items) =>
+		HashSet<Guid> ComputeBlacklistedGroupIds(IEnumerable<(Guid GroupId, string Path)> items) =>
 			GroupBlacklistFilter.ComputeBlacklistedGroupIds(items, GroupBlacklist);
 
 		public ReactiveCommand<Unit, Unit> OpenBlacklistManagerCommand => ReactiveCommand.Create(() => {
@@ -2090,7 +2091,7 @@ Non-Windows setup:
 				await ExportScanResults(BackupScanResultsFile);
 		}
 
-		private void DropSingletonGroups() {
+		void DropSingletonGroups() {
 			var singletonGroups = Duplicates
 				.GroupBy(d => d.ItemInfo.GroupId)
 				.Where(g => g.Count() <= 1)
@@ -2109,7 +2110,7 @@ Non-Windows setup:
 		/// of each other. Within each group, keep only one representative per set
 		/// of hardlinked files.
 		/// </summary>
-		private void DropHardLinkDuplicates() {
+		void DropHardLinkDuplicates() {
 			var toRemove = new List<DuplicateItemVM>();
 			foreach (var group in Duplicates.GroupBy(d => d.ItemInfo.GroupId)) {
 				var items = group.ToList();

--- a/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Filter.cs
@@ -50,7 +50,7 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		private HashSet<Guid> _groupsWithPathHit = new();
+		HashSet<Guid> _groupsWithPathHit = new();
 		void RebuildSearchPathIndex() {
 			var needle = FilterByPath;
 			if (string.IsNullOrEmpty(needle)) { _groupsWithPathHit.Clear(); return; }

--- a/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_Settings.cs
@@ -200,7 +200,7 @@ namespace VDF.GUI.ViewModels {
 					SettingsFile.Instance.Blacklists.Add(item);
 			}
 		});
-		
+
 		public ReactiveCommand<Unit, Unit> AddBlacklistPatternToListCommand => ReactiveCommand.CreateFromTask(async () => {
 			var result = await Views.InputBoxService.Show(App.Lang["Dialog.AddPatternPrompt"],
 				waterMark: "*.actors", title: App.Lang["Dialog.AddPattern"]);

--- a/VDF.GUI/ViewModels/QualityOrderVM.cs
+++ b/VDF.GUI/ViewModels/QualityOrderVM.cs
@@ -66,7 +66,7 @@ namespace VDF.GUI.ViewModels {
 			if (index >= 0 && index < CriteriaOrder.Count - 1) {
 				var item = CriteriaOrder[index];
 				CriteriaOrder.Move(index, index + 1);
-				SelectedItem = item; 
+				SelectedItem = item;
 			}
 		}
 	}

--- a/VDF.GUI/ViewModels/QualityOrderVM.cs
+++ b/VDF.GUI/ViewModels/QualityOrderVM.cs
@@ -50,7 +50,7 @@ namespace VDF.GUI.ViewModels {
 			return new(key, display == lookupKey ? key : display);
 		}
 
-		private QualityCriterionOption _selectedItem;
+		QualityCriterionOption _selectedItem;
 		public QualityCriterionOption SelectedItem {
 			get => _selectedItem;
 			set => this.RaiseAndSetIfChanged(ref _selectedItem, value);

--- a/VDF.GUI/ViewModels/RelocateFilesDialogVM.cs
+++ b/VDF.GUI/ViewModels/RelocateFilesDialogVM.cs
@@ -45,26 +45,26 @@ namespace VDF.GUI.ViewModels {
 		public FileEntry Entry { get; }
 		public string OldPath => Entry.Path;
 
-		private string? _newPath;
+		string? _newPath;
 		public string? NewPath {
 			get => _newPath;
 			set => this.RaiseAndSetIfChanged(ref _newPath, value);
 		}
 
-		private bool _selected;
+		bool _selected;
 		public bool Selected {
 			get => _selected;
 			set => this.RaiseAndSetIfChanged(ref _selected, value);
 		}
 
-		private RelocateConfidence _confidence;
+		RelocateConfidence _confidence;
 		public RelocateConfidence Confidence {
 			get => _confidence;
 			set => this.RaiseAndSetIfChanged(ref _confidence, value);
 		}
 		public string ConfidenceString => Confidence.ToString();
 
-		private string _note = string.Empty;
+		string _note = string.Empty;
 		public string Note {
 			get => _note;
 			set => this.RaiseAndSetIfChanged(ref _note, value);
@@ -75,10 +75,11 @@ namespace VDF.GUI.ViewModels {
 		}
 	}
 	internal class RelocateFilesDialogVM : ReactiveObject {
-		private readonly Window _owner;
-		private readonly HashSet<FileEntry> _entries;
-		private readonly string TempDatabaseFile;
-		private readonly DatabaseWrapper DbWrapper;
+		readonly Window _owner;
+		readonly HashSet<FileEntry> _entries;
+		readonly string TempDatabaseFile;
+
+		readonly DatabaseWrapper DbWrapper;
 		// Only forwarded to ScanEngine.ExportDataBaseToJson (which serializes through
 		// its own typed metadata); local (de)serialization uses CoreJsonContext directly.
 		static readonly JsonSerializerOptions serializerOptions = new() {

--- a/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
+++ b/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
@@ -34,7 +34,7 @@ namespace VDF.GUI.ViewModels {
 	public sealed class ThumbnailComparerVM : ReactiveObject {
 		public ObservableCollection<LargeThumbnailDuplicateItem> Items { get; }
 
-		private LargeThumbnailDuplicateItem? _selectedItemA;
+		LargeThumbnailDuplicateItem? _selectedItemA;
 		public LargeThumbnailDuplicateItem? SelectedItemA {
 			get => _selectedItemA;
 			set {
@@ -46,7 +46,7 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		private LargeThumbnailDuplicateItem? _selectedItemB;
+		LargeThumbnailDuplicateItem? _selectedItemB;
 		public LargeThumbnailDuplicateItem? SelectedItemB {
 			get => _selectedItemB;
 			set {
@@ -58,16 +58,16 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		private Bitmap? _imageA;
+		Bitmap? _imageA;
 		public Bitmap? ImageA { get => _imageA; set => this.RaiseAndSetIfChanged(ref _imageA, value); }
 
-		private Bitmap? _imageB;
+		Bitmap? _imageB;
 		public Bitmap? ImageB { get => _imageB; set => this.RaiseAndSetIfChanged(ref _imageB, value); }
 		public Bitmap? ImageSingle => ImageA ?? ImageB;
 
 		public ReadOnlyObservableCollection<CompareMode> CompareModes { get; }
 		readonly ObservableCollection<CompareMode> compareModes = new();
-		private CompareMode _selectedCompareMode = SettingsFile.Instance.ThumbnailComparerMode;
+		CompareMode _selectedCompareMode = SettingsFile.Instance.ThumbnailComparerMode;
 		public CompareMode SelectedCompareMode {
 			get => _selectedCompareMode;
 			set {
@@ -90,17 +90,17 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		private bool _isLoadingThumbnails;
+		bool _isLoadingThumbnails;
 		public bool IsLoadingThumbnails { get => _isLoadingThumbnails; set => this.RaiseAndSetIfChanged(ref _isLoadingThumbnails, value); }
 
-		private double _loadProgress;
+		double _loadProgress;
 		public double LoadProgress { get => _loadProgress; set => this.RaiseAndSetIfChanged(ref _loadProgress, value); }
 		public string LoadProgressText => $"{Math.Round(LoadProgress * 100)}%";
 
-		private string? _userMessage;
+		string? _userMessage;
 		public string? UserMessage { get => _userMessage; set => this.RaiseAndSetIfChanged(ref _userMessage, value); }
 
-		private bool _isMessageVisible;
+		bool _isMessageVisible;
 		public bool IsMessageVisible { get => _isMessageVisible; set => this.RaiseAndSetIfChanged(ref _isMessageVisible, value); }
 
 		CancellationTokenSource? _messageCts;
@@ -127,7 +127,7 @@ namespace VDF.GUI.ViewModels {
 		public bool IsDualView => IsSideBySide || IsStacked;
 		public bool SwipeHintVisible => IsSwipe;
 
-		private double _modeSliderValue = 0.5;
+		double _modeSliderValue = 0.5;
 		public double ModeSliderValue {
 			get => _modeSliderValue;
 			set {
@@ -138,7 +138,7 @@ namespace VDF.GUI.ViewModels {
 
 		// --- Highlight differences (red boxes around regions where A and B differ) ---
 
-		private bool _highlightDifferences = SettingsFile.Instance.ThumbnailComparerHighlightDifferences;
+		bool _highlightDifferences = SettingsFile.Instance.ThumbnailComparerHighlightDifferences;
 		public bool HighlightDifferences {
 			get => _highlightDifferences;
 			set {
@@ -147,7 +147,7 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		private double _diffSensitivity = SettingsFile.Instance.ThumbnailComparerDiffSensitivity;
+		double _diffSensitivity = SettingsFile.Instance.ThumbnailComparerDiffSensitivity;
 		public double DiffSensitivity {
 			get => _diffSensitivity;
 			set {
@@ -158,10 +158,10 @@ namespace VDF.GUI.ViewModels {
 
 		// Transparent bitmap with the region outlines; rendered as a second
 		// Stretch=Uniform Image over each pane, so it tracks zoom/pan for free.
-		private Bitmap? _diffOverlay;
+		Bitmap? _diffOverlay;
 		public Bitmap? DiffOverlay { get => _diffOverlay; private set => this.RaiseAndSetIfChanged(ref _diffOverlay, value); }
 
-		private bool _isComputingDiff;
+		bool _isComputingDiff;
 		public bool IsComputingDiff { get => _isComputingDiff; private set => this.RaiseAndSetIfChanged(ref _isComputingDiff, value); }
 
 		CancellationTokenSource? _diffCts;
@@ -203,21 +203,21 @@ namespace VDF.GUI.ViewModels {
 
 		// --- Frame stepping (works in ALL modes) ---
 
-		private bool _showFrameControls;
+		bool _showFrameControls;
 		public bool ShowFrameControls {
 			get => _showFrameControls;
 			private set => this.RaiseAndSetIfChanged(ref _showFrameControls, value);
 		}
 
 		// Only show position slider when there are multiple base positions to choose from
-		private bool _showPositionControls;
+		bool _showPositionControls;
 		public bool ShowPositionControls {
 			get => _showPositionControls;
 			private set => this.RaiseAndSetIfChanged(ref _showPositionControls, value);
 		}
 
 		// Selects which pre-extracted thumbnail position to start from
-		private int _baseThumbnailIndex;
+		int _baseThumbnailIndex;
 		public int BaseThumbnailIndex {
 			get => _baseThumbnailIndex;
 			set {
@@ -227,14 +227,15 @@ namespace VDF.GUI.ViewModels {
 				UpdateStripCurrent();
 			}
 		}
-		private int _baseThumbnailIndexMax;
+
+		int _baseThumbnailIndexMax;
 		public int BaseThumbnailIndexMax {
 			get => _baseThumbnailIndexMax;
 			private set => this.RaiseAndSetIfChanged(ref _baseThumbnailIndexMax, value);
 		}
 
 		// Independent frame step for A
-		private int _stepA;
+		int _stepA;
 		public int StepA {
 			get => _stepA;
 			set {
@@ -244,7 +245,7 @@ namespace VDF.GUI.ViewModels {
 		}
 
 		// Independent frame step for B
-		private int _stepB;
+		int _stepB;
 		public int StepB {
 			get => _stepB;
 			set {
@@ -254,22 +255,22 @@ namespace VDF.GUI.ViewModels {
 		}
 
 		// Display labels (visible in ALL modes)
-		private string _frameLabelA = string.Empty;
+		string _frameLabelA = string.Empty;
 		public string FrameLabelA { get => _frameLabelA; set => this.RaiseAndSetIfChanged(ref _frameLabelA, value); }
 
-		private string _frameLabelB = string.Empty;
+		string _frameLabelB = string.Empty;
 		public string FrameLabelB { get => _frameLabelB; set => this.RaiseAndSetIfChanged(ref _frameLabelB, value); }
 
-		private bool _isExtractingFrame;
+		bool _isExtractingFrame;
 		public bool IsExtractingFrame { get => _isExtractingFrame; set => this.RaiseAndSetIfChanged(ref _isExtractingFrame, value); }
 
-		private double _zoom = 1.0;
+		double _zoom = 1.0;
 		public double Zoom { get => _zoom; set => this.RaiseAndSetIfChanged(ref _zoom, value); }
 
-		private double _panOffsetX;
+		double _panOffsetX;
 		public double PanOffsetX { get => _panOffsetX; set => this.RaiseAndSetIfChanged(ref _panOffsetX, value); }
 
-		private double _panOffsetY;
+		double _panOffsetY;
 		public double PanOffsetY { get => _panOffsetY; set => this.RaiseAndSetIfChanged(ref _panOffsetY, value); }
 
 		public ReactiveCommand<Unit, Unit> FitToViewCommand { get; }
@@ -291,29 +292,29 @@ namespace VDF.GUI.ViewModels {
 		public double TopOffset { get => _top; private set => this.RaiseAndSetIfChanged(ref _top, value); }
 		double _dispW, _dispH, _left, _top;
 
-		private Geometry? _swipeClip;
+		Geometry? _swipeClip;
 		public Geometry? SwipeClip { get => _swipeClip; private set => this.RaiseAndSetIfChanged(ref _swipeClip, value); }
 
 		public Thickness SeparatorMargin => new(SeparatorX, TopOffset, 0, 0);
-		private double _separatorX;
+		double _separatorX;
 		public double SeparatorX {
 			get => _separatorX;
 			private set { this.RaiseAndSetIfChanged(ref _separatorX, value); this.RaisePropertyChanged(nameof(SeparatorMargin)); }
 		}
 
-		private double _separatorY;
+		double _separatorY;
 		public double SeparatorY {
 			get => _separatorY;
 			private set => this.RaiseAndSetIfChanged(ref _separatorY, value);
 		}
 
-		private double _viewportWidth;
+		double _viewportWidth;
 		public double ViewportWidth {
 			get => _viewportWidth;
 			set { this.RaiseAndSetIfChanged(ref _viewportWidth, value); Recalc(); }
 		}
 
-		private double _viewportHeight;
+		double _viewportHeight;
 		public double ViewportHeight {
 			get => _viewportHeight;
 			set { this.RaiseAndSetIfChanged(ref _viewportHeight, value); Recalc(); }

--- a/VDF.GUI/Views/AboutWindow.xaml.cs
+++ b/VDF.GUI/Views/AboutWindow.xaml.cs
@@ -83,6 +83,6 @@ namespace VDF.GUI.Views {
 
 		void OnOk(object? sender, RoutedEventArgs e) => Close();
 
-		private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 	}
 }

--- a/VDF.GUI/Views/ChooseAlgoView.axaml.cs
+++ b/VDF.GUI/Views/ChooseAlgoView.axaml.cs
@@ -18,11 +18,11 @@ public partial class ChooseAlgoView : Window {
 		set => SetValue(StepIndexProperty, value);
 	}
 
-	private Button? backButton;
-	private Button? skipButton;
-	private Button? nextButton;
-	private Button? finishButton;
-	private ListBox? includesListBox;
+	Button? backButton;
+	Button? skipButton;
+	Button? nextButton;
+	Button? finishButton;
+	ListBox? includesListBox;
 
 	public ChooseAlgoView() {
 		InitializeComponent();
@@ -45,12 +45,13 @@ public partial class ChooseAlgoView : Window {
 		PropertyChanged += ChooseAlgoView_PropertyChanged;
 		UpdateStepControls();
 	}
-	private void ChooseAlgoView_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) {
+
+	void ChooseAlgoView_PropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e) {
 		if (e.Property == StepIndexProperty)
 			UpdateStepControls();
 	}
 
-	private void UpdateStepControls() {
+	void UpdateStepControls() {
 		if (backButton == null || skipButton == null || nextButton == null || finishButton == null)
 			return;
 
@@ -60,13 +61,13 @@ public partial class ChooseAlgoView : Window {
 		finishButton.IsVisible = StepIndex >= 2;
 	}
 
-	private void DragOver(object? sender, DragEventArgs e) {
+	void DragOver(object? sender, DragEventArgs e) {
 		e.DragEffects &= (DragDropEffects.Copy | DragDropEffects.Link);
 		if (!e.DataTransfer.Contains(DataFormat.File))
 			e.DragEffects = DragDropEffects.None;
 	}
 
-	private void DropInclude(object? sender, DragEventArgs e) {
+	void DropInclude(object? sender, DragEventArgs e) {
 		if (!e.DataTransfer.Contains(DataFormat.File))
 			return;
 
@@ -81,7 +82,7 @@ public partial class ChooseAlgoView : Window {
 		}
 	}
 
-	private async void AddFolder_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	async void AddFolder_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		var options = new FolderPickerOpenOptions {
 			AllowMultiple = true,
 			Title = App.Lang["Dialog.SelectFolder"]
@@ -97,7 +98,7 @@ public partial class ChooseAlgoView : Window {
 		}
 	}
 
-	private void RemoveFolder_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	void RemoveFolder_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		if (includesListBox?.SelectedItems == null || includesListBox.SelectedItems.Count == 0)
 			return;
 
@@ -106,19 +107,19 @@ public partial class ChooseAlgoView : Window {
 			SettingsFile.Instance.Includes.Remove(item);
 	}
 
-	private void Back_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	void Back_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		StepIndex = Math.Max(0, StepIndex - 1);
 	}
 
-	private void Next_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	void Next_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		StepIndex = Math.Min(2, StepIndex + 1);
 	}
 
-	private void Skip_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	void Skip_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		Close();
 	}
 
-	private void Finish_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+	void Finish_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 		Close();
 	}
 }

--- a/VDF.GUI/Views/DatabaseViewer.xaml.cs
+++ b/VDF.GUI/Views/DatabaseViewer.xaml.cs
@@ -50,7 +50,7 @@ namespace VDF.GUI.Views {
 			list.AddHandler(KeyDownEvent, OnListKeyDown, RoutingStrategies.Tunnel);
 		}
 
-		private void DatabaseViewer_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
+		void DatabaseViewer_Closing(object? sender, System.ComponentModel.CancelEventArgs e)
 			=> VM.Save();
 
 		void InitializeComponent() => AvaloniaXamlLoader.Load(this);

--- a/VDF.GUI/Views/ExpressionBuilder.xaml.cs
+++ b/VDF.GUI/Views/ExpressionBuilder.xaml.cs
@@ -34,7 +34,7 @@ namespace VDF.GUI.Views {
 				RequestedThemeVariant = Avalonia.Styling.ThemeVariant.Light;
 		}
 
-		void InitializeComponent() => AvaloniaXamlLoader.Load(this);		
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
 	}
 }

--- a/VDF.GUI/Views/InputBoxView.xaml.cs
+++ b/VDF.GUI/Views/InputBoxView.xaml.cs
@@ -68,7 +68,8 @@ namespace VDF.GUI.Views {
 				};
 			}
 		}
-		private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 	}
 
 }

--- a/VDF.GUI/Views/LogView.xaml.cs
+++ b/VDF.GUI/Views/LogView.xaml.cs
@@ -25,7 +25,7 @@ namespace VDF.GUI.Views {
 
 		// Only offer "Open In Folder" when the right-clicked log line actually
 		// resolves to a file/folder that exists; otherwise suppress the menu.
-		private void LogContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e) {
+		void LogContextMenu_Opening(object? sender, System.ComponentModel.CancelEventArgs e) {
 			if (DataContext is MainWindowVM vm &&
 				MainWindowVM.TryExtractExistingPath((vm.SelectedLogItem as LogMessageRow)?.Message) == null)
 				e.Cancel = true;

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -137,7 +137,7 @@ namespace VDF.GUI.Views {
 				VDF.Core.Utils.DatabaseUtils.Create16x16Database();
 		}
 
-		private void MainWindow_Opened(object? sender, EventArgs e) {
+		void MainWindow_Opened(object? sender, EventArgs e) {
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 				/*
 				 * Due to Avalonia bug, window is bigger than screen size.

--- a/VDF.GUI/Views/MainWindow.xaml.cs
+++ b/VDF.GUI/Views/MainWindow.xaml.cs
@@ -126,7 +126,7 @@ namespace VDF.GUI.Views {
 			if (File.Exists(FileUtils.SafePathCombine(
 					CoreUtils.ResolveDatabaseFolder(SettingsFile.Instance.CustomDatabaseFolder),
 					"ScannedFiles.db")))
-					return;
+				return;
 
 			while (!this.IsVisible) {
 				await Task.Delay(200);

--- a/VDF.GUI/Views/MessageBoxView.xaml.cs
+++ b/VDF.GUI/Views/MessageBoxView.xaml.cs
@@ -83,7 +83,7 @@ namespace VDF.GUI.Views {
 		}
 
 
-		private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 	}
 
 

--- a/VDF.GUI/Views/QualityOrderDialog.xaml.cs
+++ b/VDF.GUI/Views/QualityOrderDialog.xaml.cs
@@ -17,10 +17,11 @@ namespace VDF.GUI.Views {
 
 		public QualityOrderVM ViewModel => (QualityOrderVM)DataContext!;
 
-		private void Ok_Click(object? sender, RoutedEventArgs e) {
+		void Ok_Click(object? sender, RoutedEventArgs e) {
 			Close(ViewModel.CriteriaOrder.Select(o => o.Key).ToList());
 		}
-		private void Cancel_Click(object? sender, RoutedEventArgs e) {
+
+		void Cancel_Click(object? sender, RoutedEventArgs e) {
 			Close();
 		}
 	}

--- a/VDF.GUI/Views/RelocateFilesDialog.axaml.cs
+++ b/VDF.GUI/Views/RelocateFilesDialog.axaml.cs
@@ -9,8 +9,7 @@ using VDF.GUI.ViewModels;
 
 namespace VDF.GUI;
 
-public partial class RelocateFilesDialog : Window
-{
+public partial class RelocateFilesDialog : Window {
 	public RelocateFilesDialog() {
 		AvaloniaXamlLoader.Load(this);
 		DataContext = new RelocateFilesDialogVM(this);

--- a/VDF.GUI/Views/ThumbnailComparer.xaml.cs
+++ b/VDF.GUI/Views/ThumbnailComparer.xaml.cs
@@ -70,9 +70,9 @@ namespace VDF.GUI.Views {
 		}
 		void InitializeComponent() => AvaloniaXamlLoader.Load(this);
 
-		private void ThumbnailComparer_Opened(object? sender, EventArgs e) => ApplySavedWindowPlacement();
+		void ThumbnailComparer_Opened(object? sender, EventArgs e) => ApplySavedWindowPlacement();
 
-		private void ThumbnailComparer_Loaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
+		void ThumbnailComparer_Loaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
 			if (DataContext is ThumbnailComparerVM vm) {
 				_ = vm.LoadThumbnailsAsync();
 
@@ -99,7 +99,7 @@ namespace VDF.GUI.Views {
 			}
 		}
 
-		private void ThumbnailComparer_Closing(object? sender, System.ComponentModel.CancelEventArgs e) {
+		void ThumbnailComparer_Closing(object? sender, System.ComponentModel.CancelEventArgs e) {
 			// A close mid-load must stop the thumbnail/frame extraction work — the
 			// window is gone, nothing should keep FFmpeg grinding in the background.
 			if (DataContext is ThumbnailComparerVM vm)
@@ -153,7 +153,7 @@ namespace VDF.GUI.Views {
 			}
 		}
 
-		private void ApplySavedWindowPlacement() {
+		void ApplySavedWindowPlacement() {
 			var settings = SettingsFile.Instance;
 			var screens = Screens;
 			var targetScreen = ResolveScreen(screens, settings.ThumbnailComparerWindowScreenIndex);
@@ -199,7 +199,7 @@ namespace VDF.GUI.Views {
 			WindowStartupLocation = WindowStartupLocation.CenterScreen;
 		}
 
-		private void SaveWindowPlacement() {
+		void SaveWindowPlacement() {
 			var settings = SettingsFile.Instance;
 			settings.ThumbnailComparerWindowWidth = Width;
 			settings.ThumbnailComparerWindowHeight = Height;
@@ -230,7 +230,7 @@ namespace VDF.GUI.Views {
 			SettingsFile.SaveSettings();
 		}
 
-		private static Screen? ResolveScreen(Screens? screens, int? screenIndex) {
+		static Screen? ResolveScreen(Screens? screens, int? screenIndex) {
 			if (screens == null) {
 				return null;
 			}


### PR DESCRIPTION
Based on the comment [here](https://github.com/0x90d/videoduplicatefinder/pull/883#issuecomment-5225798577):

> please match house style: tabs instead of spaces (see .editorconfig), no trailing whitespace, block-scoped namespaces, no private modifiers.

I ran `dotnet format whitespace` to trim/fix *some* whitespace issues then went through each change manually. There were some strange changes, and some things currently have incorrect levels of indentation, so I avoided those and tried to keep only things that were consistent with how most things already are.

One option to actually prompt or enforce the removal of `private` modifiers would be to change the `dotnet_style_require_accessibility_modifiers` setting to something like `omit_if_default:suggestion`. But that will also suggest removing redundant `internal` modifiers. If that'd be acceptable then I'd throw that in here as well.