### PR TITLE
Fix 2 flaky tests

### DIFF
--- a/VDF.GUI.Tests/FolderCountingServiceTests.cs
+++ b/VDF.GUI.Tests/FolderCountingServiceTests.cs
@@ -71,17 +71,26 @@ namespace VDF.GUI.Tests {
 
 		[Fact]
 		public void DuplicateRequests_AreDeduplicated() {
-			// Enough files that the first walk is still running when the second starts.
-			for (int i = 0; i < 200; i++)
-				WriteFile($@"many\file{i}.mp4");
+			// Provide one file to ensure progress reporting happens before completion.
+			WriteFile(@"many\file.mp4");
 
-			var service = new FolderCountingService();
+			var service = new FolderCountingService(TimeSpan.Zero);
 			using var done = new System.Threading.ManualResetEventSlim();
-			bool first = service.StartCounting(root, p => { if (p.Completed) done.Set(); });
+			using var continueFirst = new System.Threading.ManualResetEventSlim();
+			bool first = service.StartCounting(root, p => {
+				if (!p.Completed) {
+					continueFirst.Wait();
+				}
+				else {
+					done.Set();
+				}
+			});
 			bool second = service.StartCounting(root, _ => { });
 
 			Assert.True(first);
 			Assert.False(second);
+
+			continueFirst.Set();
 			Assert.True(done.Wait(TimeSpan.FromSeconds(15)));
 
 			// After completion the folder can be counted again.

--- a/VDF.GUI.Tests/FolderCountingServiceTests.cs
+++ b/VDF.GUI.Tests/FolderCountingServiceTests.cs
@@ -70,19 +70,18 @@ namespace VDF.GUI.Tests {
 		}
 
 		[Fact]
-		public void DuplicateRequests_AreDeduplicated() {
+		public async Task DuplicateRequests_AreDeduplicated() {
 			// Provide one file to ensure progress reporting happens before completion.
 			WriteFile(@"many\file.mp4");
 
 			var service = new FolderCountingService(TimeSpan.Zero);
-			using var done = new System.Threading.ManualResetEventSlim();
+			var done = new TaskCompletionSource();
 			using var continueFirst = new System.Threading.ManualResetEventSlim();
 			bool first = service.StartCounting(root, p => {
 				if (!p.Completed) {
 					continueFirst.Wait();
-				}
-				else {
-					done.Set();
+				} else {
+					done.SetResult();
 				}
 			});
 			bool second = service.StartCounting(root, _ => { });
@@ -91,7 +90,7 @@ namespace VDF.GUI.Tests {
 			Assert.False(second);
 
 			continueFirst.Set();
-			Assert.True(done.Wait(TimeSpan.FromSeconds(15)));
+			Assert.Equal(done.Task, await Task.WhenAny(done.Task, Task.Delay(TimeSpan.FromSeconds(15))));
 
 			// After completion the folder can be counted again.
 			Assert.True(service.StartCounting(root, _ => { }));
@@ -99,24 +98,25 @@ namespace VDF.GUI.Tests {
 		}
 
 		[Fact]
-		public void Cancel_StopsWithoutCompletionReport() {
+		public async Task Cancel_StopsWithoutCompletionReport() {
 			for (int i = 0; i < 500; i++)
 				WriteFile($@"big\file{i}.mp4");
 
 			var service = new FolderCountingService(TimeSpan.Zero);
-			using var progressed = new System.Threading.ManualResetEventSlim();
+			var progressed = new TaskCompletionSource();
 			bool completed = false;
 			service.StartCounting(root, p => {
 				if (p.Completed) completed = true;
-				else progressed.Set();
+				else progressed.TrySetResult();
 			});
-			Assert.True(progressed.Wait(TimeSpan.FromSeconds(15)), "no progress before cancel");
+			var progressedOrTimedOut = await Task.WhenAny(progressed.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+			Assert.True(progressedOrTimedOut == progressed.Task, "no progress before cancel");
 			service.Cancel(root);
 
 			// Give the walk time to notice the cancellation and unwind.
 			var sw = System.Diagnostics.Stopwatch.StartNew();
 			while (service.IsCounting(root) && sw.Elapsed < TimeSpan.FromSeconds(10))
-				Thread.Sleep(20);
+				await Task.Delay(20);
 			Assert.False(service.IsCounting(root));
 			Assert.False(completed);
 		}

--- a/VDF.GUI.Tests/ResultsInteractionRulesTests.cs
+++ b/VDF.GUI.Tests/ResultsInteractionRulesTests.cs
@@ -14,6 +14,7 @@
 // */
 //
 
+using Microsoft.Extensions.Time.Testing;
 using VDF.GUI.Data;
 using VDF.GUI.ViewModels;
 
@@ -52,13 +53,18 @@ namespace VDF.GUI.Tests {
 
 		[Fact]
 		public async Task PathCopiedFlash_RapidReCopy_ExtendsInsteadOfCuttingShort() {
-			var vm = new DuplicateItemVM();
+			var timeProvider = new FakeTimeProvider();
+			var vm = new DuplicateItemVM(timeProvider);
 			var first = vm.FlashPathCopiedAsync(durationMs: 30);
 			var second = vm.FlashPathCopiedAsync(durationMs: 200);
+
+			timeProvider.Advance(TimeSpan.FromMilliseconds(30));
 			await first;
 			// The first flash's timer has expired, but the second copy is still fresh -
 			// its badge must not be hidden by the stale timer.
 			Assert.True(vm.PathCopiedFlash);
+
+			timeProvider.Advance(TimeSpan.FromMilliseconds(170));
 			await second;
 			Assert.False(vm.PathCopiedFlash);
 		}

--- a/VDF.GUI.Tests/VDF.GUI.Tests.csproj
+++ b/VDF.GUI.Tests/VDF.GUI.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/VDF.GUI/Utils/FolderCountingService.cs
+++ b/VDF.GUI/Utils/FolderCountingService.cs
@@ -71,6 +71,8 @@ namespace VDF.GUI.Utils {
 				int count = 0;
 				long bytes = 0;
 				var lastReport = System.Diagnostics.Stopwatch.StartNew();
+				var cancelled = false;
+				var faulted = false;
 				try {
 					var options = new EnumerationOptions {
 						IgnoreInaccessible = true,
@@ -88,19 +90,22 @@ namespace VDF.GUI.Utils {
 							onProgress(new FolderCountProgress(count, bytes, Completed: false));
 						}
 					}
-					onProgress(new FolderCountProgress(count, bytes, Completed: true));
 				}
 				catch (OperationCanceledException) {
 					// canceled walks report nothing further
+					cancelled = true;
 				}
 				catch (Exception) {
-					onProgress(new FolderCountProgress(count, bytes, Completed: true, Failed: true));
+					faulted = true;
 				}
 				finally {
 					lock (gate) {
 						active.Remove(folderPath);
 					}
 					cts.Dispose();
+					if (!cancelled) {
+						onProgress(new FolderCountProgress(count, bytes, Completed: true, Failed: faulted));
+					}
 				}
 			}, CancellationToken.None);
 			return true;

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -30,11 +30,18 @@ namespace VDF.GUI.ViewModels {
 
 	[DebuggerDisplay("{ItemInfo.Path,nq} - {ItemInfo.GroupId}")]
 	public sealed class DuplicateItemVM : ReactiveObject, IJsonOnDeserialized {
+		[JsonIgnore]
+		readonly TimeProvider timeProvider;
+
 		//For JSON deserialization only
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
-		public DuplicateItemVM() { }
+		public DuplicateItemVM() : this(TimeProvider.System) { }
 
-		public DuplicateItemVM(DuplicateItem item) {
+		public DuplicateItemVM(TimeProvider? timeProvider = null) {
+			this.timeProvider = timeProvider ?? TimeProvider.System;
+		}
+
+		public DuplicateItemVM(DuplicateItem item) : this() {
 			ItemInfo = item;
 			WireThumbnailUpdates();
 		}
@@ -213,7 +220,7 @@ namespace VDF.GUI.ViewModels {
 		internal async Task FlashPathCopiedAsync(int durationMs = 1500) {
 			int version = Interlocked.Increment(ref pathCopiedFlashVersion);
 			PathCopiedFlash = true;
-			await Task.Delay(durationMs);
+			await Task.Delay(TimeSpan.FromMilliseconds(durationMs), timeProvider);
 			if (version == Volatile.Read(ref pathCopiedFlashVersion))
 				PathCopiedFlash = false;
 		}


### PR DESCRIPTION
Fixes flaky tests that have failed PR builds:
`VDF.GUI.Tests.ResultsInteractionRulesTests.PathCopiedFlash_RapidReCopy_ExtendsInsteadOfCuttingShort`
https://github.com/0x90d/videoduplicatefinder/actions/runs/32352402341/job/96374209199#step:9:9
https://github.com/0x90d/videoduplicatefinder/actions/runs/31268921057/job/93131493575#step:9:9

`VDF.GUI.Tests.FolderCountingServiceTests.DuplicateRequests_AreDeduplicated`
https://github.com/0x90d/videoduplicatefinder/actions/runs/31756028544/job/94631827304#step:9:9

For `ResultsInteractionRulesTests.PathCopiedFlash_RapidReCopy_ExtendsInsteadOfCuttingShort`, I think it's due to thread/task contention. There's no guarantee that the first task gets to continue before the second, as there's no way to guarantee `Task.Delay` means "exactly this long". It has to mean "at least this long", since the thread pool can be busy. Making the delays artificial using a `FakeTimeProvider` solves this and also makes the test complete instantly.

For `FolderCountingServiceTests.DuplicateRequests_AreDeduplicated`, I think there was one real issue, one unlikely issue, and one fix just for simplicity/correctness.

First the correctness change. I don't think creating 200 files was necessary. The logic to start the first counting task, mark that path as being active, then try to start the second task all looks like it's synchronous on the same thread with nothing else inbetween (unless `Task.Run` can run the provided body synchronously in some cases. I don't know for sure that it *never* does, but I don't think it does). But that's just how `StartCounting` is implemented right now. So instead I changed it so it makes sure the progress callback is called after the 1 file, blocks continuing until the second counting tries & fails to start, then lets the first finish. This is hacky and relies on the `onProgress` callback being executed synchronously, but works well.

The "unlikely issue" is one I ran into when artificially trying to induce the flakiness. Stressing the thread pool and running this test hundreds of times in parallel could make the timeout run out and fail the test. I don't think any of what I've changed will properly fix that, maybe just mitigate it slightly as a side effect by not blocking the thread when waiting.

I think the "real issue" was that completion was reported via `onProgress` before the guard was actually removed. This would create a race condition where the third counting could try to start before the first had removed itself from the `active` dictionary. This is easily fixed by just calling the callback after the bookkeeping is done.