### PR TITLE
Fix build warnings

### DIFF
--- a/VDF.Core.Tests/Utils/PauseTokenSourceTests.cs
+++ b/VDF.Core.Tests/Utils/PauseTokenSourceTests.cs
@@ -30,27 +30,27 @@ public class PauseTokenSourceTests {
 	// WITHOUT an exception when the scan is canceled (the old throwing wait broke into
 	// the debugger as "user-unhandled" on every Stop pressed during a pause).
 	[Fact]
-	public void TryWait_CanceledWhilePaused_ReturnsFalseInsteadOfThrowing() {
+	public async Task TryWait_CanceledWhilePaused_ReturnsFalseInsteadOfThrowing() {
 		var pts = new PauseTokenSource { IsPaused = true };
 		using var cts = new CancellationTokenSource();
 
 		var worker = Task.Run(() => pts.TryWaitWhilePaused(cts.Token));
-		Assert.False(worker.Wait(150)); // parked at the gate
+		Assert.False(await worker.TryWaitAsync(TimeSpan.FromMilliseconds(150))); // parked at the gate
 
 		cts.Cancel();
-		Assert.True(worker.Wait(TimeSpan.FromSeconds(10)), "worker did not unwind after cancel");
-		Assert.False(worker.Result);
+		Assert.True(await worker.TryWaitAsync(TimeSpan.FromSeconds(10)), "worker did not unwind after cancel");
+		Assert.False(await worker);
 	}
 
 	[Fact]
-	public void TryWait_ResumedWhilePaused_ReturnsTrue() {
+	public async Task TryWait_ResumedWhilePaused_ReturnsTrue() {
 		var pts = new PauseTokenSource { IsPaused = true };
 		var worker = Task.Run(() => pts.TryWaitWhilePaused(CancellationToken.None));
-		Assert.False(worker.Wait(150));
+		Assert.False(await worker.TryWaitAsync(TimeSpan.FromMilliseconds(150)));
 
 		pts.IsPaused = false;
-		Assert.True(worker.Wait(TimeSpan.FromSeconds(10)));
-		Assert.True(worker.Result);
+		Assert.True(await worker.TryWaitAsync(TimeSpan.FromSeconds(10)));
+		Assert.True(await worker);
 	}
 
 	[Fact]

--- a/VDF.Core.Tests/Utils/PeriodicCheckpointTests.cs
+++ b/VDF.Core.Tests/Utils/PeriodicCheckpointTests.cs
@@ -94,7 +94,7 @@ public class PeriodicCheckpointTests {
 		using var inSave = new ManualResetEventSlim();
 		using var release = new ManualResetEventSlim();
 		int runs = 0, skipped = 0;
-		Thread.Sleep(5); // let the interval elapse
+		await Task.Delay(5); // let the interval elapse
 
 		var saver = Task.Run(() => checkpoint.TryRun(() => {
 			Interlocked.Increment(ref runs);

--- a/VDF.Core.Tests/Utils/PeriodicCheckpointTests.cs
+++ b/VDF.Core.Tests/Utils/PeriodicCheckpointTests.cs
@@ -89,7 +89,7 @@ public class PeriodicCheckpointTests {
 	/// on a multi-gigabyte write instead of costing one worker.
 	/// </summary>
 	[Fact]
-	public void ConcurrentWorkersSkipInsteadOfQueueing() {
+	public async Task ConcurrentWorkersSkipInsteadOfQueueing() {
 		var checkpoint = new PeriodicCheckpoint(TimeSpan.FromMilliseconds(1));
 		using var inSave = new ManualResetEventSlim();
 		using var release = new ManualResetEventSlim();
@@ -107,10 +107,10 @@ public class PeriodicCheckpointTests {
 			if (!checkpoint.TryRun(() => Interlocked.Increment(ref runs)))
 				Interlocked.Increment(ref skipped);
 		})).ToArray();
-		Assert.True(Task.WaitAll(others, 5_000), "a worker blocked behind the save in flight");
+		Assert.True(await Task.WhenAll(others).TryWaitAsync(TimeSpan.FromSeconds(5)), "a worker blocked behind the save in flight");
 
 		release.Set();
-		saver.Wait(5_000);
+		await saver.TryWaitAsync(TimeSpan.FromSeconds(5));
 		Assert.Equal(1, runs);
 		Assert.Equal(4, skipped);
 	}

--- a/VDF.Core/Utils/Extensions.cs
+++ b/VDF.Core/Utils/Extensions.cs
@@ -57,5 +57,14 @@ namespace VDF.Core.Utils {
 			return string.Create(CultureInfo.InvariantCulture, $"{value:0.0}{SizeSuffixes[place]}");
 		}
 		public static long BytesToMegaBytes(this long byteCount) => (long)((byteCount / 1024f) / 1024f);
+
+		public static async Task<bool> TryWaitAsync(this Task t, TimeSpan timeout) {
+			try {
+				await t.WaitAsync(timeout);
+				return true;
+			} catch (TimeoutException) {
+				return false;
+			}
+		}
 	}
 }

--- a/VDF.IntegrationTests/FFTools/VideoStreamDecoderTests.cs
+++ b/VDF.IntegrationTests/FFTools/VideoStreamDecoderTests.cs
@@ -103,7 +103,7 @@ public class VideoStreamDecoderTests {
 	/// two calls; the second must still decode because its budget starts fresh.
 	/// </summary>
 	[SkippableFact]
-	public void TryDecodeFrame_TimeoutBudgetIsPerPosition_NotPerDecoderLifetime() {
+	public async Task TryDecodeFrame_TimeoutBudgetIsPerPosition_NotPerDecoderLifetime() {
 		Skip.If(!_fixture.NativeBindingAvailable, "FFmpeg native libraries not available");
 		Skip.If(_fixture.H264_8bit == null, "H264 test video not generated");
 
@@ -113,7 +113,7 @@ public class VideoStreamDecoderTests {
 
 		// Outlive the construction-time deadline. With the old lifetime deadline the
 		// interrupt callback now reports "expired" for every subsequent blocking call.
-		Thread.Sleep(800);
+		await Task.Delay(800);
 
 		Assert.True(vsd.TryDecodeFrame(out _, TimeSpan.FromSeconds(1)),
 			"second position failed after idling past the timeout — the deadline was not re-armed per call");

--- a/VDF.Web.Tests/Components/ResultsPageTests.cs
+++ b/VDF.Web.Tests/Components/ResultsPageTests.cs
@@ -25,7 +25,7 @@ namespace VDF.Web.Tests.Components;
 
 /// <summary>Renders the real Results page over seeded duplicates.</summary>
 [Collection("WebSettingsOverride")]
-public sealed class ResultsPageTests : TestContext {
+public sealed class ResultsPageTests : BunitContext {
 	readonly ScanService scan;
 
 	public ResultsPageTests() {
@@ -53,7 +53,7 @@ public sealed class ResultsPageTests : TestContext {
 	}
 
 	IRenderedComponent<VDF.Web.Components.Pages.Results> RenderPage() =>
-		RenderComponent<VDF.Web.Components.Pages.Results>();
+		Render<VDF.Web.Components.Pages.Results>();
 
 	[Fact]
 	public void NoDuplicates_ShowsTheEmptyStateInsteadOfTheToolbar() {

--- a/VDF.Web.Tests/Components/SettingsPageTests.cs
+++ b/VDF.Web.Tests/Components/SettingsPageTests.cs
@@ -26,7 +26,7 @@ namespace VDF.Web.Tests.Components;
 /// executed.
 /// </summary>
 [Collection("WebSettingsOverride")]
-public sealed class SettingsPageTests : TestContext {
+public sealed class SettingsPageTests : BunitContext {
 	readonly ScanService scan;
 
 	public SettingsPageTests() {
@@ -46,7 +46,7 @@ public sealed class SettingsPageTests : TestContext {
 	}
 
 	IRenderedComponent<VDF.Web.Components.Pages.Settings> RenderPage() =>
-		RenderComponent<VDF.Web.Components.Pages.Settings>();
+		Render<VDF.Web.Components.Pages.Settings>();
 
 	[Theory]
 	[InlineData("120", 100f)] // above range

--- a/VDF.Web.Tests/VDF.Web.Tests.csproj
+++ b/VDF.Web.Tests/VDF.Web.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit" Version="1.40.0" />
+    <PackageReference Include="bunit" Version="2.9.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
Fixes build warnings from using blocking (and potentially deadlocking) `Task.Wait` and `Task.WaitAll` calls by replacing them with an extension method wrapping `WaitAsync`, providing the same behaviour but with async.

Updates bUnit to the latest version to update the transitive dependency that had a security vulnerability.

Not related to build warnings, but also replaces two of the three remaining `Thread.Sleep` calls because I was doing async stuff, noticed them, and they were trivial to replace.