### PR TITLE
Fix logging test file path

### DIFF
--- a/VDF.Core.Tests/Utils/LoggerTests.cs
+++ b/VDF.Core.Tests/Utils/LoggerTests.cs
@@ -18,10 +18,12 @@ using VDF.Core.Utils;
 
 namespace VDF.Core.Tests.Utils;
 
-public class LoggerTests {
+[CollectionDefinition(nameof(LoggerTests), DisableParallelization = true)]
+[Collection(nameof(LoggerTests))]
+public class LoggerTests : IDisposable {
+	public LoggerTests() => File.Delete(Logger.LogFilePath);
+	public void Dispose() => File.Delete(Logger.LogFilePath);
 
-	// The Logger is a process-wide singleton whose event other parallel tests could
-	// also raise; tag messages with a unique marker and filter on it.
 	static List<LogEntry> Capture(Action<Logger> act, string marker) {
 		var captured = new List<LogEntry>();
 		void Handler(LogEntry entry) {
@@ -73,12 +75,7 @@ public class LoggerTests {
 		Logger.Instance.Error($"file error {marker}");
 		Logger.Instance.BeginSession($"Scan {marker}");
 
-		// Permissive sharing: parallel tests log through the same singleton and their
-		// appends must not be locked out (nor fail this read) while we look.
-		string content;
-		using (var stream = new FileStream(Logger.LogFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
-		using (var reader = new StreamReader(stream))
-			content = reader.ReadToEnd();
+		var content = File.ReadAllText(Logger.LogFilePath);
 		Assert.Contains($"=> file info {marker}", content);
 		Assert.Contains($"=> [WARNING] file warn {marker}", content);
 		Assert.Contains($"=> [ERROR] file error {marker}", content);

--- a/VDF.Core/Utils/CoreUtils.cs
+++ b/VDF.Core/Utils/CoreUtils.cs
@@ -22,7 +22,7 @@ namespace VDF.Core.Utils {
 		public static string CurrentFolder;
 		static CoreUtils() {
 			IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-			CurrentFolder = Path.GetDirectoryName(Environment.ProcessPath)!;
+			CurrentFolder = AppContext.BaseDirectory;
 		}
 
 		/// <summary>


### PR DESCRIPTION
This makes `CoreUtils.CurrentFolder` more reliably point to the application's directory by using `AppContext.BaseDirectory` instead of `Environment.ProcessPath`, then makes the logger tests no longer run in parallel and clean up before & after.

`Environment.ProcessPath` will point to the installed `dotnet` executable when running tests or if the user runs programs using `dotnet path/to/dll`.

I noticed this when one of the logger tests failed just once (another flaky test I guess) and found it had always been appending to a file inside my .NET installation directory, without ever cleaning it up. After fixing the path issue, I've made the logger tests no longer run in parallel and delete the log file before & after each test, just to make sure there are no future issues.