### PR TITLE
Replace property backing fields with `field` keyword

### DIFF
--- a/VDF.Core/FFTools/FfmpegEngine.cs
+++ b/VDF.Core/FFTools/FfmpegEngine.cs
@@ -27,26 +27,24 @@ using VDF.Core.Utils;
 
 namespace VDF.Core.FFTools {
 	internal static class FfmpegEngine {
-		static string _FFmpegPath = string.Empty;
 		// Re-probes when unresolved (or the binary vanished): a once-only static cache made
 		// an FFmpeg installed/downloaded while the app was running invisible until restart,
 		// so the GUI kept offering the download forever (issue #788).
 		public static string FFmpegPath {
 			get {
-				if (_FFmpegPath.Length == 0 || !File.Exists(_FFmpegPath))
-					_FFmpegPath = FFToolsUtils.GetPath(FFToolsUtils.FFTool.FFmpeg) ?? string.Empty;
-				return _FFmpegPath;
+				if (field.Length == 0 || !File.Exists(field))
+					field = FFToolsUtils.GetPath(FFToolsUtils.FFTool.FFmpeg) ?? string.Empty;
+				return field;
 			}
-		}
+		} = string.Empty;
 		const int TimeoutDuration = 15_000; //15 seconds
 		public static FFHardwareAccelerationMode HardwareAccelerationMode;
 		public static string CustomFFArguments = string.Empty;
 
-		static bool _useNativeBinding;
 		public static bool UseNativeBinding {
-			get => _useNativeBinding;
+			get;
 			set {
-				_useNativeBinding = value;
+				field = value;
 				// Reset the per-scan native-health state whenever native binding is (re)configured,
 				// i.e. at the start of each scan.
 				_nativeConsecutiveFailures = 0;

--- a/VDF.Core/ScanEngine.cs
+++ b/VDF.Core/ScanEngine.cs
@@ -67,16 +67,15 @@ namespace VDF.Core {
 			progressHeartbeat = new Timer(_ => HeartbeatTick(), null,
 											Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
 
-		bool _isScanning;
 		// The main process yields CPU to foreground apps while a scan runs, restored the
 		// instant scanning ends — hooked on the setter so EVERY exit path (done/abort/stop
 		// via CancelAllTasks) restores. BelowNormal only cedes under contention, so an
 		// unattended scan still runs at full speed. Best-effort.
 		bool isScanning {
-			get => _isScanning;
+			get;
 			set {
-				if (_isScanning == value) return;
-				_isScanning = value;
+				if (field == value) return;
+				field = value;
 				progressHeartbeat.Change(
 					value ? progressHeartbeatIntervall : Timeout.InfiniteTimeSpan,
 					value ? progressHeartbeatIntervall : Timeout.InfiniteTimeSpan);

--- a/VDF.GUI/Controls/MiddleEllipsisTextBlock.cs
+++ b/VDF.GUI/Controls/MiddleEllipsisTextBlock.cs
@@ -45,18 +45,12 @@ namespace VDF.GUI.Controls {
 			get => GetValue(TextProperty);
 			set => SetValue(TextProperty, value);
 		}
-		public IBrush? Foreground {
-			get => GetValue(ForegroundProperty);
-			set => SetValue(ForegroundProperty, value);
-		}
+		public IBrush? Foreground => GetValue(ForegroundProperty);
 		public double FontSize {
 			get => GetValue(FontSizeProperty);
 			set => SetValue(FontSizeProperty, value);
 		}
-		public FontFamily FontFamily {
-			get => GetValue(FontFamilyProperty);
-			set => SetValue(FontFamilyProperty, value);
-		}
+		public FontFamily FontFamily => GetValue(FontFamilyProperty);
 
 		TextLayout CreateLayout(string text) =>
 			new(text, new Typeface(FontFamily), FontSize, Foreground);

--- a/VDF.GUI/Data/SettingsFile.cs
+++ b/VDF.GUI/Data/SettingsFile.cs
@@ -60,671 +60,573 @@ namespace VDF.GUI.Data {
 		public ObservableCollection<string> Includes { get; set; } = new();
 		[JsonPropertyName("Blacklists")]
 		public ObservableCollection<string> Blacklists { get; set; } = new();
-		string _LastCustomSelectExpression = string.Empty;
 		[JsonPropertyName("LastCustomSelectExpression")]
 		public string LastCustomSelectExpression {
-			get => _LastCustomSelectExpression;
-			set => this.RaiseAndSetIfChanged(ref _LastCustomSelectExpression, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 
-		ObservableCollection<string> _ExpressionHistory = new();
 		[JsonPropertyName("ExpressionHistory")]
 		public ObservableCollection<string> ExpressionHistory {
-			get => _ExpressionHistory;
-			set => this.RaiseAndSetIfChanged(ref _ExpressionHistory, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 
-		ObservableCollection<ExpressionPreset> _ExpressionPresets = new();
 		[JsonPropertyName("ExpressionPresets")]
 		public ObservableCollection<ExpressionPreset> ExpressionPresets {
-			get => _ExpressionPresets;
-			set => this.RaiseAndSetIfChanged(ref _ExpressionPresets, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 
-		ObservableCollection<CustomSelectionPreset> _CustomSelectionPresets = new();
 		[JsonPropertyName("CustomSelectionPresets")]
 		public ObservableCollection<CustomSelectionPreset> CustomSelectionPresets {
-			get => _CustomSelectionPresets;
-			set => this.RaiseAndSetIfChanged(ref _CustomSelectionPresets, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 
-		bool _AutoApplySelectionPresetEnabled;
 		[JsonPropertyName("AutoApplySelectionPresetEnabled")]
 		public bool AutoApplySelectionPresetEnabled {
-			get => _AutoApplySelectionPresetEnabled;
-			set => this.RaiseAndSetIfChanged(ref _AutoApplySelectionPresetEnabled, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		string _AutoApplySelectionPreset = string.Empty;
 		/// <summary>Name of the custom-selection preset applied automatically after every scan.</summary>
 		[JsonPropertyName("AutoApplySelectionPreset")]
 		public string AutoApplySelectionPreset {
-			get => _AutoApplySelectionPreset;
-			set => this.RaiseAndSetIfChanged(ref _AutoApplySelectionPreset, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 
-		double? _MainWindowWidth;
 		[JsonPropertyName("MainWindowWidth")]
 		public double? MainWindowWidth {
-			get => _MainWindowWidth;
-			set => this.RaiseAndSetIfChanged(ref _MainWindowWidth, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double? _MainWindowHeight;
 		[JsonPropertyName("MainWindowHeight")]
 		public double? MainWindowHeight {
-			get => _MainWindowHeight;
-			set => this.RaiseAndSetIfChanged(ref _MainWindowHeight, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int? _MainWindowPositionX;
 		[JsonPropertyName("MainWindowPositionX")]
 		public int? MainWindowPositionX {
-			get => _MainWindowPositionX;
-			set => this.RaiseAndSetIfChanged(ref _MainWindowPositionX, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int? _MainWindowPositionY;
 		[JsonPropertyName("MainWindowPositionY")]
 		public int? MainWindowPositionY {
-			get => _MainWindowPositionY;
-			set => this.RaiseAndSetIfChanged(ref _MainWindowPositionY, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _MainWindowMaximized;
 		[JsonPropertyName("MainWindowMaximized")]
 		public bool MainWindowMaximized {
-			get => _MainWindowMaximized;
-			set => this.RaiseAndSetIfChanged(ref _MainWindowMaximized, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		string _LanguageCode = ResolveDefaultLanguageCode();
 		[JsonPropertyName("LanguageCode")]
 		public string LanguageCode {
-			get => _LanguageCode;
-			set => this.RaiseAndSetIfChanged(ref _LanguageCode, ResolveLanguageCode(value));
-		}
-		bool _IgnoreReadOnlyFolders;
+			get => field;
+			set => this.RaiseAndSetIfChanged(ref field, ResolveLanguageCode(value));
+		} = ResolveDefaultLanguageCode();
 		[JsonPropertyName("IgnoreReadOnlyFolders")]
 		public bool IgnoreReadOnlyFolders {
-			get => _IgnoreReadOnlyFolders;
-			set => this.RaiseAndSetIfChanged(ref _IgnoreReadOnlyFolders, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _ExcludeHardLinks;
 		[JsonPropertyName("ExcludeHardLinks")]
 		public bool ExcludeHardLinks {
-			get => _ExcludeHardLinks;
-			set => this.RaiseAndSetIfChanged(ref _ExcludeHardLinks, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _IgnoreReparsePoints;
 		[JsonPropertyName("IgnoreReparsePoints")]
 		public bool IgnoreReparsePoints {
-			get => _IgnoreReparsePoints;
-			set => this.RaiseAndSetIfChanged(ref _IgnoreReparsePoints, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 		// IgnoreBlackPixels/IgnoreWhitePixels/CompareHorizontallyFlipped/Percent defaults
 		// form the "Edited & altered copies" scan profile — the recommended default for
 		// fresh installs (redesign stage 2). Existing settings files carry explicit
 		// values for every key, so nobody's configuration changes.
-		bool _IgnoreBlackPixels = true;
 		[JsonPropertyName("IgnoreBlackPixels")]
 		public bool IgnoreBlackPixels {
-			get => _IgnoreBlackPixels;
-			set => this.RaiseAndSetIfChanged(ref _IgnoreBlackPixels, value);
-		}
-		bool _IgnoreWhitePixels = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("IgnoreWhitePixels")]
 		public bool IgnoreWhitePixels {
-			get => _IgnoreWhitePixels;
-			set => this.RaiseAndSetIfChanged(ref _IgnoreWhitePixels, value);
-		}
-		int _MaxDegreeOfParallelism = -1;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("MaxDegreeOfParallelism")]
 		public int MaxDegreeOfParallelism {
-			get => _MaxDegreeOfParallelism;
-			set => this.RaiseAndSetIfChanged(ref _MaxDegreeOfParallelism, value);
-		}
-		int _MatchingMaxDegreeOfParallelism;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = -1;
 		/// <summary>Worker cap for the CPU-bound matching phases; 0 or less = automatic CPU-headroom cap — see Core setting.</summary>
 		[JsonPropertyName("MatchingMaxDegreeOfParallelism")]
 		public int MatchingMaxDegreeOfParallelism {
-			get => _MatchingMaxDegreeOfParallelism;
-			set => this.RaiseAndSetIfChanged(ref _MatchingMaxDegreeOfParallelism, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int _HddMaxDegreeOfParallelism = 2;
 		/// <summary>Per-drive cap for slow drives (spindle HDDs / network shares) — see Core setting.</summary>
 		[JsonPropertyName("HddMaxDegreeOfParallelism")]
 		public int HddMaxDegreeOfParallelism {
-			get => _HddMaxDegreeOfParallelism;
-			set => this.RaiseAndSetIfChanged(ref _HddMaxDegreeOfParallelism, value);
-		}
-		Dictionary<string, string> _DriveTypeOverrides = new(StringComparer.OrdinalIgnoreCase);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 2;
 		/// <summary>Drive root → "SSD"/"HDD" scan-concurrency overrides. No editor UI yet
 		/// (planned with the per-drive scan rows); power users can edit Settings.json.</summary>
 		[JsonPropertyName("DriveTypeOverrides")]
 		public Dictionary<string, string> DriveTypeOverrides {
-			get => _DriveTypeOverrides;
+			get;
 			// STJ drops the comparer on deserialization — re-wrap so drive letters stay case-insensitive.
-			set => _DriveTypeOverrides = value == null
+			set => field = value == null
 				? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
 				: new Dictionary<string, string>(value, StringComparer.OrdinalIgnoreCase);
-		}
-		bool _WelcomeStripDismissed;
+		} = new(StringComparer.OrdinalIgnoreCase);
 		/// <summary>The Setup screen's "New here?" hint strip, dismissible once.</summary>
 		[JsonPropertyName("WelcomeStripDismissed")]
 		public bool WelcomeStripDismissed {
-			get => _WelcomeStripDismissed;
-			set => this.RaiseAndSetIfChanged(ref _WelcomeStripDismissed, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		ScanKnobs? _CustomScanKnobs;
 		/// <summary>Snapshot of the profile-managed knobs from when the user last left a
 		/// custom configuration; selecting the Custom profile restores it.</summary>
 		[JsonPropertyName("CustomScanKnobs")]
 		public ScanKnobs? CustomScanKnobs {
-			get => _CustomScanKnobs;
-			set => this.RaiseAndSetIfChanged(ref _CustomScanKnobs, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		Core.FFTools.FFHardwareAccelerationMode _HardwareAccelerationMode = Core.FFTools.FFHardwareAccelerationMode.auto;
 		[JsonPropertyName("HardwareAccelerationMode")]
 		public Core.FFTools.FFHardwareAccelerationMode HardwareAccelerationMode {
-			get => _HardwareAccelerationMode;
-			set => this.RaiseAndSetIfChanged(ref _HardwareAccelerationMode, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = Core.FFTools.FFHardwareAccelerationMode.auto;
 		// Part of the "Edited & altered copies" default profile (see IgnoreBlackPixels note).
-		bool _CompareHorizontallyFlipped = true;
 		[JsonPropertyName("CompareHorizontallyFlipped")]
 		public bool CompareHorizontallyFlipped {
-			get => _CompareHorizontallyFlipped;
-			set => this.RaiseAndSetIfChanged(ref _CompareHorizontallyFlipped, value);
-		}
-		bool _IncludeSubDirectories = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("IncludeSubDirectories")]
 		public bool IncludeSubDirectories {
-			get => _IncludeSubDirectories;
-			set => this.RaiseAndSetIfChanged(ref _IncludeSubDirectories, value);
-		}
-		bool _IncludeImages = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("IncludeImages")]
 		public bool IncludeImages {
-			get => _IncludeImages;
-			set => this.RaiseAndSetIfChanged(ref _IncludeImages, value);
-		}
-		bool _GeneratePreviewThumbnails = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("GeneratePreviewThumbnails")]
 		public bool GeneratePreviewThumbnails {
-			get => _GeneratePreviewThumbnails;
-			set => this.RaiseAndSetIfChanged(ref _GeneratePreviewThumbnails, value);
-		}
-		int _ThumbnailMaxWidth = 100;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ThumbnailMaxWidth")]
 		public int ThumbnailMaxWidth {
-			get => _ThumbnailMaxWidth;
+			get;
 			set {
 				int clamped = Math.Clamp(value, 48, 960);
-				if (clamped == _ThumbnailMaxWidth) return;
-				this.RaiseAndSetIfChanged(ref _ThumbnailMaxWidth, clamped);
+				if (clamped == field) return;
+				this.RaiseAndSetIfChanged(ref field, clamped);
 				// The old view sized its layout from this extraction width; keep that
 				// behavior by moving the results Preview column along. The drag grip can
 				// still diverge afterwards (a persisted ResultsPreviewWidth is loaded
 				// after this property and wins on startup).
 				ResultsPreviewWidth = clamped;
 			}
-		}
-		bool _ExtendedFFToolsLogging;
+		} = 100;
 		[JsonPropertyName("ExtendedFFToolsLogging")]
 		public bool ExtendedFFToolsLogging {
-			get => _ExtendedFFToolsLogging;
-			set => this.RaiseAndSetIfChanged(ref _ExtendedFFToolsLogging, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _LogExcludedFiles;
 		[JsonPropertyName("LogExcludedFiles")]
 		public bool LogExcludedFiles {
-			get => _LogExcludedFiles;
-			set => this.RaiseAndSetIfChanged(ref _LogExcludedFiles, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _AlwaysRetryFailedSampling = false;
 		[JsonPropertyName("AlwaysRetryFailedSampling")]
 		public bool AlwaysRetryFailedSampling {
-			get => _AlwaysRetryFailedSampling;
-			set => this.RaiseAndSetIfChanged(ref _AlwaysRetryFailedSampling, value);
-		}
-		bool _UseNativeFfmpegBinding;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = false;
 		[JsonPropertyName("UseNativeFfmpegBinding")]
 		public bool UseNativeFfmpegBinding {
-			get => _UseNativeFfmpegBinding;
-			set => this.RaiseAndSetIfChanged(ref _UseNativeFfmpegBinding, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		string _CustomFFArguments = string.Empty;
 		[JsonPropertyName("CustomFFArguments")]
 		public string CustomFFArguments {
-			get => _CustomFFArguments;
-			set => this.RaiseAndSetIfChanged(ref _CustomFFArguments, value);
-		}
-		bool _BackupAfterListChanged = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
+
 		[JsonPropertyName("BackupAfterListChanged")]
 		public bool BackupAfterListChanged {
-			get => _BackupAfterListChanged;
-			set => this.RaiseAndSetIfChanged(ref _BackupAfterListChanged, value);
-		}
-		bool _AskToSaveResultsOnExit = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("AskToSaveResultsOnExit")]
 		public bool AskToSaveResultsOnExit {
-			get => _AskToSaveResultsOnExit;
-			set => this.RaiseAndSetIfChanged(ref _AskToSaveResultsOnExit, value);
-		}
-		bool _IncludeNonExistingFiles;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("IncludeNonExistingFiles")]
 		public bool IncludeNonExistingFiles {
-			get => _IncludeNonExistingFiles;
-			set => this.RaiseAndSetIfChanged(ref _IncludeNonExistingFiles, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _RememberDeletedContent;
 		[JsonPropertyName("RememberDeletedContent")]
 		public bool RememberDeletedContent {
-			get => _RememberDeletedContent;
-			set => this.RaiseAndSetIfChanged(ref _RememberDeletedContent, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _AutoCheckDeletedContentMatches;
 		[JsonPropertyName("AutoCheckDeletedContentMatches")]
 		public bool AutoCheckDeletedContentMatches {
-			get => _AutoCheckDeletedContentMatches;
-			set => this.RaiseAndSetIfChanged(ref _AutoCheckDeletedContentMatches, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _ScanAgainstEntireDatabase;
 		[JsonPropertyName("ScanAgainstEntireDatabase")]
 		public bool ScanAgainstEntireDatabase {
-			get => _ScanAgainstEntireDatabase;
-			set => this.RaiseAndSetIfChanged(ref _ScanAgainstEntireDatabase, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		Core.FolderMatchMode _FolderMatchMode;
 		[JsonPropertyName("FolderMatchMode")]
 		public Core.FolderMatchMode FolderMatchMode {
-			get => _FolderMatchMode;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _FolderMatchMode, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				this.RaisePropertyChanged(nameof(IsFolderMatchModeActive));
 			}
 		}
 		public bool IsFolderMatchModeActive => FolderMatchMode != Core.FolderMatchMode.None;
-		int _SameFolderDepth = 1;
 		[JsonPropertyName("SameFolderDepth")]
 		public int SameFolderDepth {
-			get => _SameFolderDepth;
-			set => this.RaiseAndSetIfChanged(ref _SameFolderDepth, value);
-		}
-		bool _UsePHash;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 1;
 		[JsonPropertyName("UsePHash")]
 		public bool UsePHash {
-			get => _UsePHash;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _UsePHash, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				this.RaisePropertyChanged(nameof(PHashComparisonActive));
 			}
 		}
-		bool _CombineGrayPHash;
 		/// <summary>#842: run grayscale AND pHash in one comparison pass and badge which algorithm found each group. Takes precedence over UsePHash.</summary>
 		[JsonPropertyName("CombineGrayPHash")]
 		public bool CombineGrayPHash {
-			get => _CombineGrayPHash;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _CombineGrayPHash, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				this.RaisePropertyChanged(nameof(PHashComparisonActive));
 			}
 		}
 		/// <summary>The pHash comparison (and its sample-quorum setting) is in play - alone or combined.</summary>
 		[JsonIgnore]
 		public bool PHashComparisonActive => UsePHash || CombineGrayPHash;
-		float _PHashSampleRatioPercent = 60f;
 		/// <summary>Percentage of sampled frame positions that must individually pass the pHash threshold — see Core's PHashRequiredMatchingSampleRatio (0..1).</summary>
 		[JsonPropertyName("PHashSampleRatioPercent")]
 		public float PHashSampleRatioPercent {
-			get => _PHashSampleRatioPercent;
-			set => this.RaiseAndSetIfChanged(ref _PHashSampleRatioPercent, Math.Clamp(value, 1f, 100f));
-		}
-		bool _UseAiMatching;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 1f, 100f));
+		} = 60f;
 		[JsonPropertyName("UseAiMatching")]
 		public bool UseAiMatching {
-			get => _UseAiMatching;
-			set => this.RaiseAndSetIfChanged(ref _UseAiMatching, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		float _AiPercent = 94f;
 		/// <summary>Similarity threshold (percent = cosine·100) for the AI matching pass.</summary>
 		[JsonPropertyName("AiPercent")]
 		public float AiPercent {
-			get => _AiPercent;
-			set => this.RaiseAndSetIfChanged(ref _AiPercent, Math.Clamp(value, 50f, 100f));
-		}
-		bool _EnableAiPartialDetection;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 50f, 100f));
+		} = 94f;
 		[JsonPropertyName("EnableAiPartialDetection")]
 		public bool EnableAiPartialDetection {
-			get => _EnableAiPartialDetection;
-			set => this.RaiseAndSetIfChanged(ref _EnableAiPartialDetection, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		float _AiPartialHitPercent = 89f;
 		/// <summary>Per-frame hit threshold (percent) for the visual partial-duplicate pass.</summary>
 		[JsonPropertyName("AiPartialHitPercent")]
 		public float AiPartialHitPercent {
-			get => _AiPartialHitPercent;
-			set => this.RaiseAndSetIfChanged(ref _AiPartialHitPercent, Math.Clamp(value, 70f, 99f));
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 70f, 99f));
+		} = 89f;
 		/// <summary>GUI mirror of Core Settings.NeedsAiComponents — keep the two in sync.</summary>
 		[JsonIgnore]
 		public bool NeedsAiComponents => UseAiMatching || EnableAiPartialDetection;
-		bool _UseExifCreationDate;
 		[JsonPropertyName("UseExifCreationDate")]
 		public bool UseExifCreationDate {
-			get => _UseExifCreationDate;
-			set => this.RaiseAndSetIfChanged(ref _UseExifCreationDate, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 		// Part of the "Edited & altered copies" default profile (see IgnoreBlackPixels note).
-		float _Percent = 92f;
 		[JsonPropertyName("Percent")]
 		public float Percent {
-			get => _Percent;
-			set => this.RaiseAndSetIfChanged(ref _Percent, value);
-		}
-		double _PercentDurationDifference = 20d;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 92f;
 		[JsonPropertyName("PercentDurationDifference")]
 		public double PercentDurationDifference {
-			get => _PercentDurationDifference;
-			set => this.RaiseAndSetIfChanged(ref _PercentDurationDifference, value);
-		}
-		int _DurationDifferenceMinSeconds = 0;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 20d;
 		[JsonPropertyName("DurationDifferenceMinSeconds")]
 		public int DurationDifferenceMinSeconds {
-			get => _DurationDifferenceMinSeconds;
-			set => this.RaiseAndSetIfChanged(ref _DurationDifferenceMinSeconds, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int _DurationDifferenceMaxSeconds = 0;
 		[JsonPropertyName("DurationDifferenceMaxSeconds")]
 		public int DurationDifferenceMaxSeconds {
-			get => _DurationDifferenceMaxSeconds;
-			set => this.RaiseAndSetIfChanged(ref _DurationDifferenceMaxSeconds, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int _MaxSamplingDurationSeconds = 0;
 		[JsonPropertyName("MaxSamplingDurationSeconds")]
 		public int MaxSamplingDurationSeconds {
-			get => _MaxSamplingDurationSeconds;
-			set => this.RaiseAndSetIfChanged(ref _MaxSamplingDurationSeconds, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int _Thumbnails = 1;
 		[JsonPropertyName("Thumbnails")]
 		public int Thumbnails {
-			get => _Thumbnails;
-			set => this.RaiseAndSetIfChanged(ref _Thumbnails, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 1;
 		[JsonPropertyName("CustomCommands")]
 		public CustomActionCommands CustomCommands { get; set; } = new();
-		string _CustomDatabaseFolder = string.Empty;
 		[JsonPropertyName("CustomDatabaseFolder")]
 		public string CustomDatabaseFolder {
-			get => _CustomDatabaseFolder;
-			set => this.RaiseAndSetIfChanged(ref _CustomDatabaseFolder, value);
-		}
-		int _DatabaseCheckpointIntervalMinutes = 5;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 		[JsonPropertyName("DatabaseCheckpointIntervalMinutes")]
 		public int DatabaseCheckpointIntervalMinutes {
-			get => _DatabaseCheckpointIntervalMinutes;
-			set => this.RaiseAndSetIfChanged(ref _DatabaseCheckpointIntervalMinutes, Math.Max(0, value));
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, Math.Max(0, value));
+		} = 5;
 
 		public static void SaveSettings(string? path = null) {
 			path = ResolveSettingsPath(path);
 			File.WriteAllText(path, JsonSerializer.Serialize(instance, GuiJsonContext.Default.SettingsFile));
 		}
 
-		bool _UseMica = false;
 		[JsonPropertyName("UseMica")]
 		public bool UseMica {
-			get => _UseMica;
-			set => this.RaiseAndSetIfChanged(ref _UseMica, value);
-		}
-		bool _DarkMode = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = false;
 		[JsonPropertyName("DarkMode")]
 		public bool DarkMode {
-			get => _DarkMode;
-			set => this.RaiseAndSetIfChanged(ref _DarkMode, value);
-		}
-		double? _ThumbnailComparerWindowWidth;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ThumbnailComparerWindowWidth")]
 		public double? ThumbnailComparerWindowWidth {
-			get => _ThumbnailComparerWindowWidth;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerWindowWidth, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double? _ThumbnailComparerWindowHeight;
 		[JsonPropertyName("ThumbnailComparerWindowHeight")]
 		public double? ThumbnailComparerWindowHeight {
-			get => _ThumbnailComparerWindowHeight;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerWindowHeight, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double? _ThumbnailComparerWindowPositionX;
 		[JsonPropertyName("ThumbnailComparerWindowPositionX")]
 		public double? ThumbnailComparerWindowPositionX {
-			get => _ThumbnailComparerWindowPositionX;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerWindowPositionX, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double? _ThumbnailComparerWindowPositionY;
 		[JsonPropertyName("ThumbnailComparerWindowPositionY")]
 		public double? ThumbnailComparerWindowPositionY {
-			get => _ThumbnailComparerWindowPositionY;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerWindowPositionY, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int? _ThumbnailComparerWindowScreenIndex;
 		[JsonPropertyName("ThumbnailComparerWindowScreenIndex")]
 		public int? ThumbnailComparerWindowScreenIndex {
-			get => _ThumbnailComparerWindowScreenIndex;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerWindowScreenIndex, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		// Side-by-side first (redesign stage 4, maintainer directive on comparer view modes).
-		CompareMode _ThumbnailComparerMode = CompareMode.SideBySide;
 		[JsonPropertyName("ThumbnailComparerMode")]
 		public CompareMode ThumbnailComparerMode {
-			get => _ThumbnailComparerMode;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerMode, value);
-		}
-		double _ThumbnailComparerDiffSensitivity = 0.5;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+			// Side-by-side first (redesign stage 4, maintainer directive on comparer view modes).
+		} = CompareMode.SideBySide;
 		[JsonPropertyName("ThumbnailComparerDiffSensitivity")]
 		public double ThumbnailComparerDiffSensitivity {
-			get => _ThumbnailComparerDiffSensitivity;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerDiffSensitivity, value);
-		}
-		bool _ThumbnailComparerHighlightDifferences = false;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 0.5;
 		[JsonPropertyName("ThumbnailComparerHighlightDifferences")]
 		public bool ThumbnailComparerHighlightDifferences {
-			get => _ThumbnailComparerHighlightDifferences;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailComparerHighlightDifferences, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _ShowThumbnailColumn = true;
 		[JsonPropertyName("ShowThumbnailColumn")]
 		public bool ShowThumbnailColumn {
-			get => _ShowThumbnailColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowThumbnailColumn, value);
-		}
-		bool _ShowDurationColumn = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ShowDurationColumn")]
 		public bool ShowDurationColumn {
-			get => _ShowDurationColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowDurationColumn, value);
-		}
-		bool _ShowFormatColumn = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ShowFormatColumn")]
 		public bool ShowFormatColumn {
-			get => _ShowFormatColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowFormatColumn, value);
-		}
-		bool _ShowBitrateColumn = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ShowBitrateColumn")]
 		public bool ShowBitrateColumn {
-			get => _ShowBitrateColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowBitrateColumn, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		// First-results hint: "drag the Preview handle / raise the thumbnail width" (one-shot)
-		bool _ResultsHintDismissed;
 		[JsonPropertyName("ResultsHintDismissed")]
 		public bool ResultsHintDismissed {
-			get => _ResultsHintDismissed;
-			set => this.RaiseAndSetIfChanged(ref _ResultsHintDismissed, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		bool _ShowSimilarityColumn = true;
 		[JsonPropertyName("ShowSimilarityColumn")]
 		public bool ShowSimilarityColumn {
-			get => _ShowSimilarityColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowSimilarityColumn, value);
-		}
-		bool _ShowSizeDateColumn = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ShowSizeDateColumn")]
 		public bool ShowSizeDateColumn {
-			get => _ShowSizeDateColumn;
-			set => this.RaiseAndSetIfChanged(ref _ShowSizeDateColumn, value);
-		}
-		ViewModels.ResultsSortMode _ResultsSortMode = ViewModels.ResultsSortMode.WastedSpace;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("ResultsSortMode")]
 		public ViewModels.ResultsSortMode ResultsSortMode {
-			get => _ResultsSortMode;
-			set => this.RaiseAndSetIfChanged(ref _ResultsSortMode, value);
-		}
-		bool _ResultsSortDescending = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = ViewModels.ResultsSortMode.WastedSpace;
 		[JsonPropertyName("ResultsSortDescending")]
 		public bool ResultsSortDescending {
-			get => _ResultsSortDescending;
-			set => this.RaiseAndSetIfChanged(ref _ResultsSortDescending, value);
-		}
-		bool _ResultsBestFirst;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		/// <summary>Show the BEST-badged file at the top of each group, ahead of the sort order (#846).</summary>
 		[JsonPropertyName("ResultsBestFirst")]
 		public bool ResultsBestFirst {
-			get => _ResultsBestFirst;
-			set => this.RaiseAndSetIfChanged(ref _ResultsBestFirst, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double _ResultsPreviewWidth = 160;
 		/// <summary>Width of the Preview column in the results list; scales the preview frames.
 		/// The old 480 cap made thumbnails unresizable past a quarter of a 1080p screen (#834).</summary>
 		[JsonPropertyName("ResultsPreviewWidth")]
 		public double ResultsPreviewWidth {
-			get => _ResultsPreviewWidth;
-			set => this.RaiseAndSetIfChanged(ref _ResultsPreviewWidth, Math.Clamp(value, 56, 1600));
-		}
-		bool _ResultsCompactRows;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 56, 1600));
+		} = 160;
 		[JsonPropertyName("ResultsCompactRows")]
 		public bool ResultsCompactRows {
-			get => _ResultsCompactRows;
-			set => this.RaiseAndSetIfChanged(ref _ResultsCompactRows, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		ThumbnailDoubleClickAction _ThumbnailDoubleClickAction = ThumbnailDoubleClickAction.OpenFile;
 		[JsonPropertyName("ThumbnailDoubleClickAction")]
 		public ThumbnailDoubleClickAction ThumbnailDoubleClickAction {
-			get => _ThumbnailDoubleClickAction;
-			set => this.RaiseAndSetIfChanged(ref _ThumbnailDoubleClickAction, value);
-		}
-		bool _FilterByFilePathContains;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = ThumbnailDoubleClickAction.OpenFile;
 		[JsonPropertyName("FilterByFilePathContains")]
 		public bool FilterByFilePathContains {
-			get => _FilterByFilePathContains;
-			set => this.RaiseAndSetIfChanged(ref _FilterByFilePathContains, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		ObservableCollection<string> _FilePathContainsTexts = new();
 		[JsonPropertyName("FilePathContainsTexts")]
 		public ObservableCollection<string> FilePathContainsTexts {
-			get => _FilePathContainsTexts;
-			set => this.RaiseAndSetIfChanged(ref _FilePathContainsTexts, value);
-		}
-		bool _FilterByFilePathNotContains;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 		[JsonPropertyName("FilterByFilePathNotContains")]
 		public bool FilterByFilePathNotContains {
-			get => _FilterByFilePathNotContains;
-			set => this.RaiseAndSetIfChanged(ref _FilterByFilePathNotContains, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		ObservableCollection<string> _FilePathNotContainsTexts = new();
 		[JsonPropertyName("FilePathNotContainsTexts")]
 		public ObservableCollection<string> FilePathNotContainsTexts {
-			get => _FilePathNotContainsTexts;
-			set => this.RaiseAndSetIfChanged(ref _FilePathNotContainsTexts, value);
-		}
-		bool _FilterByFileSize;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 		[JsonPropertyName("FilterByFileSize")]
 		public bool FilterByFileSize {
-			get => _FilterByFileSize;
-			set => this.RaiseAndSetIfChanged(ref _FilterByFileSize, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		int _MaximumFileSize = 999999999;
 		[JsonPropertyName("MaximumFileSize")]
 		public int MaximumFileSize {
-			get => _MaximumFileSize;
-			set => this.RaiseAndSetIfChanged(ref _MaximumFileSize, value);
-		}
-		int _MinimumFileSize = 0;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 999999999;
 		[JsonPropertyName("MinimumFileSize")]
 		public int MinimumFileSize {
-			get => _MinimumFileSize;
-			set => this.RaiseAndSetIfChanged(ref _MinimumFileSize, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 0;
 
-		bool _EnablePartialClipDetection;
 		[JsonPropertyName("EnablePartialClipDetection")]
 		public bool EnablePartialClipDetection {
-			get => _EnablePartialClipDetection;
-			set => this.RaiseAndSetIfChanged(ref _EnablePartialClipDetection, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		double _PartialClipMinRatioPercent = 10d;
 		[JsonPropertyName("PartialClipMinRatioPercent")]
 		public double PartialClipMinRatioPercent {
-			get => _PartialClipMinRatioPercent;
-			set => this.RaiseAndSetIfChanged(ref _PartialClipMinRatioPercent, value);
-		}
-		double _PartialClipSimilarityThresholdPercent = 80d;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 10d;
 		[JsonPropertyName("PartialClipSimilarityThresholdPercent")]
 		public double PartialClipSimilarityThresholdPercent {
-			get => _PartialClipSimilarityThresholdPercent;
-			set => this.RaiseAndSetIfChanged(ref _PartialClipSimilarityThresholdPercent, value);
-		}
-		bool _PartialClipRequireVisualMatch = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 80d;
 		[JsonPropertyName("PartialClipRequireVisualMatch")]
 		public bool PartialClipRequireVisualMatch {
-			get => _PartialClipRequireVisualMatch;
-			set => this.RaiseAndSetIfChanged(ref _PartialClipRequireVisualMatch, value);
-		}
-		double _PartialClipVisualThresholdPercent = 85d;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("PartialClipVisualThresholdPercent")]
 		public double PartialClipVisualThresholdPercent {
-			get => _PartialClipVisualThresholdPercent;
-			set => this.RaiseAndSetIfChanged(ref _PartialClipVisualThresholdPercent, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = 85d;
 
 		// Video bitrate ranks above FPS: among equal-resolution re-encodes bitrate is the
 		// stronger quality signal, and a marginally higher framerate must not outrank a
 		// much better encode (#839). Saved user orders are untouched.
-		List<string> _QualityCriteriaOrder = ["Duration", "Resolution", "Bitrate", "FPS", "Bits per pixel", "Audio Bitrate", "Size"];
 		[JsonPropertyName("QualityCriteriaOrder")]
 		public List<string> QualityCriteriaOrder {
-			get => _QualityCriteriaOrder;
-			set => this.RaiseAndSetIfChanged(ref _QualityCriteriaOrder, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = ["Duration", "Resolution", "Bitrate", "FPS", "Bits per pixel", "Audio Bitrate", "Size"];
 
-		bool _EnableScheduledScan;
 		[JsonPropertyName("EnableScheduledScan")]
 		public bool EnableScheduledScan {
-			get => _EnableScheduledScan;
-			set => this.RaiseAndSetIfChanged(ref _EnableScheduledScan, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
-		string _ScheduledScanTime = "02:00";
 		[JsonPropertyName("ScheduledScanTime")]
 		public string ScheduledScanTime {
-			get => _ScheduledScanTime;
-			set => this.RaiseAndSetIfChanged(ref _ScheduledScanTime, value);
-		}
-		bool _NotifyOnScheduledScanComplete = true;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = "02:00";
 		[JsonPropertyName("NotifyOnScheduledScanComplete")]
 		public bool NotifyOnScheduledScanComplete {
-			get => _NotifyOnScheduledScanComplete;
-			set => this.RaiseAndSetIfChanged(ref _NotifyOnScheduledScanComplete, value);
-		}
-		bool _NotifyOnScanComplete;
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 		[JsonPropertyName("NotifyOnScanComplete")]
 		public bool NotifyOnScanComplete {
-			get => _NotifyOnScanComplete;
-			set => this.RaiseAndSetIfChanged(ref _NotifyOnScanComplete, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		Dictionary<string, string> _KeyboardShortcuts = new();
 		[JsonPropertyName("KeyboardShortcuts")]
 		public Dictionary<string, string> KeyboardShortcuts {
-			get => _KeyboardShortcuts;
-			set => this.RaiseAndSetIfChanged(ref _KeyboardShortcuts, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = new();
 
 		public static void LoadSettings(string? path = null) {
 			path ??= settingsPath;

--- a/VDF.GUI/LanguageService.cs
+++ b/VDF.GUI/LanguageService.cs
@@ -27,19 +27,17 @@ using ReactiveUI;
 namespace VDF.GUI {
 	public class LanguageService : ReactiveObject {
 		Dictionary<string, string> _translations = new();
-		string _currentLanguage = "en";
 
-		IReadOnlyList<string>? _availableLanguages;
-		public IReadOnlyList<string> AvailableLanguages => _availableLanguages ??= LoadAvailableLanguages();
+		public IReadOnlyList<string> AvailableLanguages => field ??= LoadAvailableLanguages();
 		public string CurrentLanguage {
-			get => _currentLanguage;
+			get;
 			set {
-				if (EqualityComparer<string>.Default.Equals(_currentLanguage, value))
+				if (EqualityComparer<string>.Default.Equals(field, value))
 					return;
-				this.RaiseAndSetIfChanged(ref _currentLanguage, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				LoadLanguage(value);
 			}
-		}
+		} = "en";
 
 		public void LoadLanguage(string langCode) {
 			try {

--- a/VDF.GUI/ViewModels/BlacklistManagerVM.cs
+++ b/VDF.GUI/ViewModels/BlacklistManagerVM.cs
@@ -54,11 +54,10 @@ namespace VDF.GUI.ViewModels {
 			ClearAllCommand = ReactiveCommand.CreateFromTask(ClearAllAsync);
 		}
 
-		string _statusMessage = string.Empty;
 		public string StatusMessage {
-			get => _statusMessage;
-			private set => this.RaiseAndSetIfChanged(ref _statusMessage, value);
-		}
+			get;
+			private set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 
 		void RebuildEntries() {
 			Entries.Clear();

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -30,7 +30,6 @@ namespace VDF.GUI.ViewModels {
 
 	[DebuggerDisplay("{ItemInfo.Path,nq} - {ItemInfo.GroupId}")]
 	public sealed class DuplicateItemVM : ReactiveObject, IJsonOnDeserialized {
-		[JsonIgnore]
 		readonly TimeProvider timeProvider;
 
 		//For JSON deserialization only
@@ -121,9 +120,7 @@ namespace VDF.GUI.ViewModels {
 		}
 		public DuplicateItem ItemInfo { get; set; }
 
-		[JsonIgnore]
 		Utils.ThumbnailSizePrediction? _thumbnailPrediction;
-		[JsonIgnore]
 		bool thumbnailPredictionComputed;
 		/// <summary>
 		/// Final-size prediction for the not-yet-loaded composite so the row reserves its
@@ -171,8 +168,7 @@ namespace VDF.GUI.ViewModels {
 			set => this.RaiseAndSetIfChanged(ref _ThumbnailGridColumns, value);
 		}
 
-		[JsonIgnore] Bitmap? _thumbnail;
-
+		Bitmap? _thumbnail;
 		[JsonIgnore]
 		public Bitmap? Thumbnail {
 			get {
@@ -278,7 +274,6 @@ namespace VDF.GUI.ViewModels {
 		/// <summary>
 		///   Returns if item matches the filter conditions
 		/// </summary>
-		[JsonIgnore]
 		internal bool IsVisibleInFilter = true;
 
 		public bool EqualsFull(DuplicateItemVM other) {

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -168,7 +168,6 @@ namespace VDF.GUI.ViewModels {
 			set => this.RaiseAndSetIfChanged(ref _ThumbnailGridColumns, value);
 		}
 
-		Bitmap? _thumbnail;
 		[JsonIgnore]
 		public Bitmap? Thumbnail {
 			get {
@@ -190,7 +189,6 @@ namespace VDF.GUI.ViewModels {
 					return null;
 				}
 			}
-			set => this.RaiseAndSetIfChanged(ref _thumbnail, value);
 		}
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
@@ -260,7 +258,6 @@ namespace VDF.GUI.ViewModels {
 		string? _AudioSampleRateDiff;
 		[JsonIgnore]
 		public string? AudioSampleRateDiff {
-			get => _AudioSampleRateDiff;
 			set => this.RaiseAndSetIfChanged(ref _AudioSampleRateDiff, value);
 		}
 

--- a/VDF.GUI/ViewModels/DuplicateItemVM.cs
+++ b/VDF.GUI/ViewModels/DuplicateItemVM.cs
@@ -120,7 +120,6 @@ namespace VDF.GUI.ViewModels {
 		}
 		public DuplicateItem ItemInfo { get; set; }
 
-		Utils.ThumbnailSizePrediction? _thumbnailPrediction;
 		bool thumbnailPredictionComputed;
 		/// <summary>
 		/// Final-size prediction for the not-yet-loaded composite so the row reserves its
@@ -132,11 +131,11 @@ namespace VDF.GUI.ViewModels {
 			get {
 				if (!thumbnailPredictionComputed && ItemInfo != null) {
 					thumbnailPredictionComputed = true;
-					_thumbnailPrediction = Utils.ThumbnailSizePrediction.For(ItemInfo,
+					field = Utils.ThumbnailSizePrediction.For(ItemInfo,
 						_ThumbnailFrameCount, _ThumbnailGridColumns,
 						SettingsFile.Instance.Thumbnails, SettingsFile.Instance.ThumbnailMaxWidth);
 				}
-				return _thumbnailPrediction;
+				return field;
 			}
 		}
 
@@ -192,18 +191,16 @@ namespace VDF.GUI.ViewModels {
 		}
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
-		bool _Checked;
 		public bool Checked {
-			get => _Checked;
-			set => this.RaiseAndSetIfChanged(ref _Checked, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		bool _PathCopiedFlash;
 		/// <summary>Transient "Copied" badge next to the path after a deliberate copy click (#849).</summary>
 		[JsonIgnore]
 		public bool PathCopiedFlash {
-			get => _PathCopiedFlash;
-			set => this.RaiseAndSetIfChanged(ref _PathCopiedFlash, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		int pathCopiedFlashVersion;
@@ -220,52 +217,45 @@ namespace VDF.GUI.ViewModels {
 		}
 
 		// Hover-diff display: when non-null, shown instead of the normal value
-		string? _DurationDiff;
 		[JsonIgnore]
 		public string? DurationDiff {
-			get => _DurationDiff;
-			set => this.RaiseAndSetIfChanged(ref _DurationDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _FrameSizeDiff;
 		[JsonIgnore]
 		public string? FrameSizeDiff {
-			get => _FrameSizeDiff;
-			set => this.RaiseAndSetIfChanged(ref _FrameSizeDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _SizeDiff;
 		[JsonIgnore]
 		public string? SizeDiff {
-			get => _SizeDiff;
-			set => this.RaiseAndSetIfChanged(ref _SizeDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _FpsDiff;
 		[JsonIgnore]
 		public string? FpsDiff {
-			get => _FpsDiff;
-			set => this.RaiseAndSetIfChanged(ref _FpsDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _BitRateDiff;
 		[JsonIgnore]
 		public string? BitRateDiff {
-			get => _BitRateDiff;
-			set => this.RaiseAndSetIfChanged(ref _BitRateDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _AudioSampleRateDiff;
 		[JsonIgnore]
 		public string? AudioSampleRateDiff {
-			set => this.RaiseAndSetIfChanged(ref _AudioSampleRateDiff, value);
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string? _AudioBitRateDiff;
 		[JsonIgnore]
 		public string? AudioBitRateDiff {
-			get => _AudioBitRateDiff;
-			set => this.RaiseAndSetIfChanged(ref _AudioBitRateDiff, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		/// <summary>

--- a/VDF.GUI/ViewModels/MainWindowVM.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM.cs
@@ -175,7 +175,6 @@ namespace VDF.GUI.ViewModels {
 		}
 		string _ScanProgressText = string.Empty;
 		public string ScanProgressText {
-			get => _ScanProgressText;
 			set => this.RaiseAndSetIfChanged(ref _ScanProgressText, value);
 		}
 		string _RemainingTime = string.Empty;

--- a/VDF.GUI/ViewModels/MainWindowVM_AiDownloader.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_AiDownloader.cs
@@ -31,21 +31,19 @@ namespace VDF.GUI.ViewModels {
 	// extraction and integrity checks live in Core (AiComponents) so the CLI can
 	// download headlessly with the identical logic.
 	public partial class MainWindowVM : ReactiveObject {
-		bool _isAiDownloadInProgress;
 		public bool IsAiDownloadInProgress {
-			get => _isAiDownloadInProgress;
-			set => this.RaiseAndSetIfChanged(ref _isAiDownloadInProgress, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		string _AiComponentsStatusText = string.Empty;
 		public string AiComponentsStatusText {
 			get {
-				if (string.IsNullOrEmpty(_AiComponentsStatusText))
-					_AiComponentsStatusText = BuildAiComponentsStatusText();
-				return _AiComponentsStatusText;
+				if (string.IsNullOrEmpty(field))
+					field = BuildAiComponentsStatusText();
+				return field;
 			}
-			set => this.RaiseAndSetIfChanged(ref _AiComponentsStatusText, value);
-		}
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 
 		static string BuildAiComponentsStatusText() => AiComponents.GetState() switch {
 			AiComponentsState.Ready => string.Format(CultureInfo.InvariantCulture, App.Lang["Settings.AiComponents.Ready"], AiComponents.RuntimeVersion),

--- a/VDF.GUI/ViewModels/MainWindowVM_FfmpegDownloader.cs
+++ b/VDF.GUI/ViewModels/MainWindowVM_FfmpegDownloader.cs
@@ -29,10 +29,9 @@ namespace VDF.GUI.ViewModels {
 	// localized install/troubleshooting messages. The download/verify/extract/install
 	// logic lives in VDF.Core.FFTools.FfmpegDownloader, shared with the Web UI.
 	public partial class MainWindowVM : ReactiveObject {
-		bool _isFfmpegDownloadInProgress;
 		public bool IsFfmpegDownloadInProgress {
-			get => _isFfmpegDownloadInProgress;
-			set => this.RaiseAndSetIfChanged(ref _isFfmpegDownloadInProgress, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		public ReactiveCommand<Unit, Unit> DownloadSharedFfmpegCommand => ReactiveCommand.CreateFromTask(async () => {

--- a/VDF.GUI/ViewModels/RelocateFilesDialogVM.cs
+++ b/VDF.GUI/ViewModels/RelocateFilesDialogVM.cs
@@ -45,30 +45,26 @@ namespace VDF.GUI.ViewModels {
 		public FileEntry Entry { get; }
 		public string OldPath => Entry.Path;
 
-		string? _newPath;
 		public string? NewPath {
-			get => _newPath;
-			set => this.RaiseAndSetIfChanged(ref _newPath, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		bool _selected;
 		public bool Selected {
-			get => _selected;
-			set => this.RaiseAndSetIfChanged(ref _selected, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		RelocateConfidence _confidence;
 		public RelocateConfidence Confidence {
-			get => _confidence;
-			set => this.RaiseAndSetIfChanged(ref _confidence, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 		public string ConfidenceString => Confidence.ToString();
 
-		string _note = string.Empty;
 		public string Note {
-			get => _note;
-			set => this.RaiseAndSetIfChanged(ref _note, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = string.Empty;
 
 		public RelocateCandidate(FileEntry e) {
 			Entry = e;
@@ -94,40 +90,33 @@ namespace VDF.GUI.ViewModels {
 		}
 
 		// Mode toggles
-		bool _isModePrefix = true;
 		public bool IsModePrefix {
-			get => _isModePrefix;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _isModePrefix, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				if (value) IsModeRescan = false;
 			}
-		}
+		} = true;
 
-		bool _isModeRescan;
 		public bool IsModeRescan {
-			get => _isModeRescan;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _isModeRescan, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				if (value) IsModePrefix = false;
 			}
 		}
 
 		// Inputs for A
-		string _oldPrefix = string.Empty;
-		public string OldPrefix { get => _oldPrefix; set => this.RaiseAndSetIfChanged(ref _oldPrefix, value); }
+		public string OldPrefix { get; set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
 
-		string _newPrefix = string.Empty;
-		public string NewPrefix { get => _newPrefix; set => this.RaiseAndSetIfChanged(ref _newPrefix, value); }
+		public string NewPrefix { get; set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
 
 		// Inputs for B
 		public ObservableCollection<string> ScanRoots { get; } = new();
-		bool _useModifiedTime = true;
-		public bool UseModifiedTime { get => _useModifiedTime; set => this.RaiseAndSetIfChanged(ref _useModifiedTime, value); }
+		public bool UseModifiedTime { get; set => this.RaiseAndSetIfChanged(ref field, value); } = true;
 
-		bool _useDuration = false;
-		public bool UseDuration { get => _useDuration; set => this.RaiseAndSetIfChanged(ref _useDuration, value); }
-		bool _IsLoading = false;
-		public bool IsLoading { get => _IsLoading; set => this.RaiseAndSetIfChanged(ref _IsLoading, value); }
+		public bool UseDuration { get; set => this.RaiseAndSetIfChanged(ref field, value); } = false;
+		public bool IsLoading { get; set => this.RaiseAndSetIfChanged(ref field, value); } = false;
 
 		// Preview
 		public AvaloniaList<RelocateCandidate> Preview { get; } = new();
@@ -181,10 +170,9 @@ namespace VDF.GUI.ViewModels {
 			}
 		});
 
-		bool _canApply;
 		public bool CanApply {
-			get => _canApply;
-			set => this.RaiseAndSetIfChanged(ref _canApply, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		// --- Core preview builders ---

--- a/VDF.GUI/ViewModels/ShortcutBindingVM.cs
+++ b/VDF.GUI/ViewModels/ShortcutBindingVM.cs
@@ -38,10 +38,9 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		string? _conflictText;
 		public string? ConflictText {
-			get => _conflictText;
-			set => this.RaiseAndSetIfChanged(ref _conflictText, value);
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		public bool IsModified => CurrentGesture != DefaultGesture;

--- a/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
+++ b/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
@@ -968,10 +968,10 @@ namespace VDF.GUI.ViewModels {
 		}
 
 		bool _isSourceA;
-		public bool IsSourceA { get => _isSourceA; set => this.RaiseAndSetIfChanged(ref _isSourceA, value); }
+		public bool IsSourceA { set => this.RaiseAndSetIfChanged(ref _isSourceA, value); }
 
 		bool _isSourceB;
-		public bool IsSourceB { get => _isSourceB; set => this.RaiseAndSetIfChanged(ref _isSourceB, value); }
+		public bool IsSourceB { set => this.RaiseAndSetIfChanged(ref _isSourceB, value); }
 
 		public LargeThumbnailDuplicateItem(DuplicateItemVM duplicateItem) {
 			Item = duplicateItem;

--- a/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
+++ b/VDF.GUI/ViewModels/ThumbnailComparerVM.cs
@@ -58,11 +58,9 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		Bitmap? _imageA;
-		public Bitmap? ImageA { get => _imageA; set => this.RaiseAndSetIfChanged(ref _imageA, value); }
+		public Bitmap? ImageA { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		Bitmap? _imageB;
-		public Bitmap? ImageB { get => _imageB; set => this.RaiseAndSetIfChanged(ref _imageB, value); }
+		public Bitmap? ImageB { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 		public Bitmap? ImageSingle => ImageA ?? ImageB;
 
 		public ReadOnlyObservableCollection<CompareMode> CompareModes { get; }
@@ -90,18 +88,14 @@ namespace VDF.GUI.ViewModels {
 			}
 		}
 
-		bool _isLoadingThumbnails;
-		public bool IsLoadingThumbnails { get => _isLoadingThumbnails; set => this.RaiseAndSetIfChanged(ref _isLoadingThumbnails, value); }
+		public bool IsLoadingThumbnails { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		double _loadProgress;
-		public double LoadProgress { get => _loadProgress; set => this.RaiseAndSetIfChanged(ref _loadProgress, value); }
+		public double LoadProgress { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 		public string LoadProgressText => $"{Math.Round(LoadProgress * 100)}%";
 
-		string? _userMessage;
-		public string? UserMessage { get => _userMessage; set => this.RaiseAndSetIfChanged(ref _userMessage, value); }
+		public string? UserMessage { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		bool _isMessageVisible;
-		public bool IsMessageVisible { get => _isMessageVisible; set => this.RaiseAndSetIfChanged(ref _isMessageVisible, value); }
+		public bool IsMessageVisible { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		CancellationTokenSource? _messageCts;
 		public void ShowMessage(string msg, int millis = 3000) {
@@ -127,42 +121,37 @@ namespace VDF.GUI.ViewModels {
 		public bool IsDualView => IsSideBySide || IsStacked;
 		public bool SwipeHintVisible => IsSwipe;
 
-		double _modeSliderValue = 0.5;
 		public double ModeSliderValue {
-			get => _modeSliderValue;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _modeSliderValue, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				Recalc();
 			}
-		}
+		} = 0.5;
 
 		// --- Highlight differences (red boxes around regions where A and B differ) ---
 
-		bool _highlightDifferences = SettingsFile.Instance.ThumbnailComparerHighlightDifferences;
 		public bool HighlightDifferences {
-			get => _highlightDifferences;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _highlightDifferences, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				SettingsFile.Instance.ThumbnailComparerHighlightDifferences = value;
 			}
-		}
+		} = SettingsFile.Instance.ThumbnailComparerHighlightDifferences;
 
-		double _diffSensitivity = SettingsFile.Instance.ThumbnailComparerDiffSensitivity;
 		public double DiffSensitivity {
-			get => _diffSensitivity;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _diffSensitivity, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				SettingsFile.Instance.ThumbnailComparerDiffSensitivity = value;
 			}
-		}
+		} = SettingsFile.Instance.ThumbnailComparerDiffSensitivity;
 
 		// Transparent bitmap with the region outlines; rendered as a second
 		// Stretch=Uniform Image over each pane, so it tracks zoom/pan for free.
-		Bitmap? _diffOverlay;
-		public Bitmap? DiffOverlay { get => _diffOverlay; private set => this.RaiseAndSetIfChanged(ref _diffOverlay, value); }
+		public Bitmap? DiffOverlay { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		bool _isComputingDiff;
-		public bool IsComputingDiff { get => _isComputingDiff; private set => this.RaiseAndSetIfChanged(ref _isComputingDiff, value); }
+		public bool IsComputingDiff { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		CancellationTokenSource? _diffCts;
 
@@ -203,75 +192,63 @@ namespace VDF.GUI.ViewModels {
 
 		// --- Frame stepping (works in ALL modes) ---
 
-		bool _showFrameControls;
 		public bool ShowFrameControls {
-			get => _showFrameControls;
-			private set => this.RaiseAndSetIfChanged(ref _showFrameControls, value);
+			get;
+			private set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		// Only show position slider when there are multiple base positions to choose from
-		bool _showPositionControls;
 		public bool ShowPositionControls {
-			get => _showPositionControls;
-			private set => this.RaiseAndSetIfChanged(ref _showPositionControls, value);
+			get;
+			private set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		// Selects which pre-extracted thumbnail position to start from
-		int _baseThumbnailIndex;
 		public int BaseThumbnailIndex {
-			get => _baseThumbnailIndex;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _baseThumbnailIndex, Math.Clamp(value, 0, Math.Max(BaseThumbnailIndexMax, 0)));
+				this.RaiseAndSetIfChanged(ref field, Math.Clamp(value, 0, Math.Max(BaseThumbnailIndexMax, 0)));
 				StepA = 0;
 				StepB = 0;
 				UpdateStripCurrent();
 			}
 		}
 
-		int _baseThumbnailIndexMax;
 		public int BaseThumbnailIndexMax {
-			get => _baseThumbnailIndexMax;
-			private set => this.RaiseAndSetIfChanged(ref _baseThumbnailIndexMax, value);
+			get;
+			private set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
 		// Independent frame step for A
-		int _stepA;
 		public int StepA {
-			get => _stepA;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _stepA, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				UpdateFrameImages();
 			}
 		}
 
 		// Independent frame step for B
-		int _stepB;
 		public int StepB {
-			get => _stepB;
+			get;
 			set {
-				this.RaiseAndSetIfChanged(ref _stepB, value);
+				this.RaiseAndSetIfChanged(ref field, value);
 				UpdateFrameImages();
 			}
 		}
 
 		// Display labels (visible in ALL modes)
-		string _frameLabelA = string.Empty;
-		public string FrameLabelA { get => _frameLabelA; set => this.RaiseAndSetIfChanged(ref _frameLabelA, value); }
+		public string FrameLabelA { get; set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
 
-		string _frameLabelB = string.Empty;
-		public string FrameLabelB { get => _frameLabelB; set => this.RaiseAndSetIfChanged(ref _frameLabelB, value); }
+		public string FrameLabelB { get; set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
 
-		bool _isExtractingFrame;
-		public bool IsExtractingFrame { get => _isExtractingFrame; set => this.RaiseAndSetIfChanged(ref _isExtractingFrame, value); }
+		public bool IsExtractingFrame { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		double _zoom = 1.0;
-		public double Zoom { get => _zoom; set => this.RaiseAndSetIfChanged(ref _zoom, value); }
+		public double Zoom { get; set => this.RaiseAndSetIfChanged(ref field, value); } = 1.0;
 
-		double _panOffsetX;
-		public double PanOffsetX { get => _panOffsetX; set => this.RaiseAndSetIfChanged(ref _panOffsetX, value); }
+		public double PanOffsetX { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		double _panOffsetY;
-		public double PanOffsetY { get => _panOffsetY; set => this.RaiseAndSetIfChanged(ref _panOffsetY, value); }
+		public double PanOffsetY { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		public ReactiveCommand<Unit, Unit> FitToViewCommand { get; }
 		public ReactiveCommand<Unit, Unit> ResetZoomCommand { get; }
@@ -286,38 +263,32 @@ namespace VDF.GUI.ViewModels {
 		public ReactiveCommand<Unit, Unit> StepBPlusCommand { get; }
 		public ReactiveCommand<Unit, Unit> ResetStepsCommand { get; }
 
-		public double DisplayWidth { get => _dispW; private set => this.RaiseAndSetIfChanged(ref _dispW, value); }
-		public double DisplayHeight { get => _dispH; private set => this.RaiseAndSetIfChanged(ref _dispH, value); }
-		public double LeftOffset { get => _left; private set => this.RaiseAndSetIfChanged(ref _left, value); }
-		public double TopOffset { get => _top; private set => this.RaiseAndSetIfChanged(ref _top, value); }
-		double _dispW, _dispH, _left, _top;
+		public double DisplayWidth { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+		public double DisplayHeight { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+		public double LeftOffset { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+		public double TopOffset { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		Geometry? _swipeClip;
-		public Geometry? SwipeClip { get => _swipeClip; private set => this.RaiseAndSetIfChanged(ref _swipeClip, value); }
+		public Geometry? SwipeClip { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		public Thickness SeparatorMargin => new(SeparatorX, TopOffset, 0, 0);
-		double _separatorX;
 		public double SeparatorX {
-			get => _separatorX;
-			private set { this.RaiseAndSetIfChanged(ref _separatorX, value); this.RaisePropertyChanged(nameof(SeparatorMargin)); }
+			get;
+			private set { this.RaiseAndSetIfChanged(ref field, value); this.RaisePropertyChanged(nameof(SeparatorMargin)); }
 		}
 
-		double _separatorY;
 		public double SeparatorY {
-			get => _separatorY;
-			private set => this.RaiseAndSetIfChanged(ref _separatorY, value);
+			get;
+			private set => this.RaiseAndSetIfChanged(ref field, value);
 		}
 
-		double _viewportWidth;
 		public double ViewportWidth {
-			get => _viewportWidth;
-			set { this.RaiseAndSetIfChanged(ref _viewportWidth, value); Recalc(); }
+			get;
+			set { this.RaiseAndSetIfChanged(ref field, value); Recalc(); }
 		}
 
-		double _viewportHeight;
 		public double ViewportHeight {
-			get => _viewportHeight;
-			set { this.RaiseAndSetIfChanged(ref _viewportHeight, value); Recalc(); }
+			get;
+			set { this.RaiseAndSetIfChanged(ref field, value); Recalc(); }
 		}
 
 		CancellationTokenSource? _frameExtractCts;
@@ -475,12 +446,9 @@ namespace VDF.GUI.ViewModels {
 
 		CullingPairFlow? _pairFlow;
 
-		string _groupInfoText = string.Empty;
-		public string GroupInfoText { get => _groupInfoText; private set => this.RaiseAndSetIfChanged(ref _groupInfoText, value); }
-		string _pairInfoText = string.Empty;
-		public string PairInfoText { get => _pairInfoText; private set => this.RaiseAndSetIfChanged(ref _pairInfoText, value); }
-		string _similarityText = string.Empty;
-		public string SimilarityText { get => _similarityText; private set => this.RaiseAndSetIfChanged(ref _similarityText, value); }
+		public string GroupInfoText { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
+		public string PairInfoText { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
+		public string SimilarityText { get; private set => this.RaiseAndSetIfChanged(ref field, value); } = string.Empty;
 		public bool HasSimilarity => !string.IsNullOrEmpty(SimilarityText);
 
 		public ObservableCollection<MetaChip> LeftChips { get; } = new();
@@ -488,10 +456,8 @@ namespace VDF.GUI.ViewModels {
 		public ObservableCollection<FrameStripEntry> StripA { get; } = new();
 		public ObservableCollection<FrameStripEntry> StripB { get; } = new();
 
-		bool _isLeftBest;
-		public bool IsLeftBest { get => _isLeftBest; private set => this.RaiseAndSetIfChanged(ref _isLeftBest, value); }
-		bool _isRightBest;
-		public bool IsRightBest { get => _isRightBest; private set => this.RaiseAndSetIfChanged(ref _isRightBest, value); }
+		public bool IsLeftBest { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
+		public bool IsRightBest { get; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		void ApplyDecision(CullingPairFlow.Decision decision) {
 			if (_pairFlow is null || Items.Count < 2) return;
@@ -944,8 +910,7 @@ namespace VDF.GUI.ViewModels {
 		}
 		public Bitmap Frame { get; }
 		public int Index { get; }
-		bool _isCurrent;
-		public bool IsCurrent { get => _isCurrent; set => this.RaiseAndSetIfChanged(ref _isCurrent, value); }
+		public bool IsCurrent { get; set => this.RaiseAndSetIfChanged(ref field, value); }
 	}
 
 	// Unsealed so tests can stub LoadThumbnail (stuck-grab cancellation regression).
@@ -961,17 +926,14 @@ namespace VDF.GUI.ViewModels {
 
 		public string FileName => System.IO.Path.GetFileName(Item.ItemInfo.Path);
 
-		bool _IsLoadingThumbnail = true;
 		public bool IsLoadingThumbnail {
-			get => _IsLoadingThumbnail;
-			set => this.RaiseAndSetIfChanged(ref _IsLoadingThumbnail, value);
-		}
+			get;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		} = true;
 
-		bool _isSourceA;
-		public bool IsSourceA { set => this.RaiseAndSetIfChanged(ref _isSourceA, value); }
+		public bool IsSourceA { set => this.RaiseAndSetIfChanged(ref field, value); }
 
-		bool _isSourceB;
-		public bool IsSourceB { set => this.RaiseAndSetIfChanged(ref _isSourceB, value); }
+		public bool IsSourceB { set => this.RaiseAndSetIfChanged(ref field, value); }
 
 		public LargeThumbnailDuplicateItem(DuplicateItemVM duplicateItem) {
 			Item = duplicateItem;


### PR DESCRIPTION
Removes unnecessary explicit backing fields for properties when they aren't used outside of the accessors, replacing them with `field`.

All the replacements in the large commit were done automatically by my IDE, with only manual whitespace changes to make it match how it already was.